### PR TITLE
Feature/allow loading filtered policy on init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea
 .vscode
 node_modules
-lib
 yarn-error.log
 
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Reason for fork
+On every check we are getting a filtered policy specific to that user. This clears the existing local policy. This means there is no reason to fetch the full policy on startup. 
+This fork implements the option to create a new enforcer and passing in a filter, so a filtered policy will be fetched instead, greatly reducing initialization time.
+
 node-Casbin
 ====
 [![NPM version][npm-image]][npm-url]

--- a/lib/casbin.d.ts
+++ b/lib/casbin.d.ts
@@ -1,0 +1,24 @@
+import { Enforcer } from './enforcer';
+import { Model } from './model';
+/**
+ * newModel creates a model.
+ */
+declare function newModel(...text: string[]): Model;
+/**
+ * newEnforcer creates an enforcer via file or DB.
+ *
+ * File:
+ * ```js
+ * const e = new Enforcer('path/to/basic_model.conf', 'path/to/basic_policy.csv');
+ * ```
+ *
+ * MySQL DB:
+ * ```js
+ * const a = new MySQLAdapter('mysql', 'mysql_username:mysql_password@tcp(127.0.0.1:3306)/');
+ * const e = new Enforcer('path/to/basic_model.conf', a);
+ * ```
+ *
+ * @param params
+ */
+declare function newEnforcer(...params: any[]): Promise<Enforcer>;
+export { newEnforcer, newModel };

--- a/lib/casbin.js
+++ b/lib/casbin.js
@@ -1,0 +1,128 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const enforcer_1 = require("./enforcer");
+const log_1 = require("./log");
+const model_1 = require("./model");
+/**
+ * newModel creates a model.
+ */
+function newModel(...text) {
+    const m = new model_1.Model();
+    if (text.length === 2) {
+        if (text[0] !== '') {
+            m.loadModel(text[0]);
+        }
+    }
+    else if (text.length === 1) {
+        m.loadModelFromText(text[0]);
+    }
+    else if (text.length !== 0) {
+        throw new Error('Invalid parameters for model.');
+    }
+    return m;
+}
+exports.newModel = newModel;
+/**
+ * newEnforcer creates an enforcer via file or DB.
+ *
+ * File:
+ * ```js
+ * const e = new Enforcer('path/to/basic_model.conf', 'path/to/basic_policy.csv');
+ * ```
+ *
+ * MySQL DB:
+ * ```js
+ * const a = new MySQLAdapter('mysql', 'mysql_username:mysql_password@tcp(127.0.0.1:3306)/');
+ * const e = new Enforcer('path/to/basic_model.conf', a);
+ * ```
+ *
+ * @param params
+ */
+function newEnforcer(...params) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const e = new enforcer_1.Enforcer();
+        let parsedParamLen = 0;
+        if (params.length >= 1) {
+            const enableLog = params[params.length - 1];
+            if (typeof enableLog === 'boolean') {
+                log_1.getLogger().enableLog(enableLog);
+                parsedParamLen++;
+            }
+        }
+        if (params.length - parsedParamLen === 3) {
+            if (typeof params[0] === 'string') {
+                if (typeof params[1] === 'string') {
+                    yield e.initWithFile(params[0].toString(), params[1].toString());
+                }
+                else {
+                    yield e.initWithAdapter(params[0].toString(), params[1], params[2]);
+                }
+            }
+            else {
+                if (typeof params[1] === 'string') {
+                    throw new Error('Invalid parameters for enforcer.');
+                }
+                else {
+                    yield e.initWithModelAndAdapter(params[0], params[1]);
+                }
+            }
+        }
+        else if (params.length - parsedParamLen === 2) {
+            if (typeof params[0] === 'string') {
+                if (typeof params[1] === 'string') {
+                    yield e.initWithFile(params[0].toString(), params[1].toString());
+                }
+                else {
+                    yield e.initWithAdapter(params[0].toString(), params[1]);
+                }
+            }
+            else {
+                if (typeof params[1] === 'string') {
+                    throw new Error('Invalid parameters for enforcer.');
+                }
+                else {
+                    yield e.initWithModelAndAdapter(params[0], params[1]);
+                }
+            }
+        }
+        else if (params.length - parsedParamLen === 1) {
+            if (typeof params[0] === 'string') {
+                yield e.initWithFile(params[0], '');
+            }
+            else {
+                // @ts-ignore
+                yield e.initWithModelAndAdapter(params[0], null);
+            }
+        }
+        else if (params.length === parsedParamLen) {
+            yield e.initWithFile('', '');
+        }
+        else {
+            throw new Error('Invalid parameters for enforcer.');
+        }
+        return e;
+    });
+}
+exports.newEnforcer = newEnforcer;

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -1,0 +1,36 @@
+export declare class Config {
+    private static DEFAULT_SECTION;
+    private static DEFAULT_COMMENT;
+    private static DEFAULT_COMMENT_SEM;
+    private static DEFAULT_MULTI_LINE_SEPARATOR;
+    private data;
+    private constructor();
+    /**
+     * newConfig create an empty configuration representation from file.
+     *
+     * @param confName the path of the model file.
+     * @return the constructor of Config.
+     */
+    static newConfig(confName: string): Config;
+    /**
+     * newConfigFromText create an empty configuration representation from text.
+     *
+     * @param text the model text.
+     * @return the constructor of Config.
+     */
+    static newConfigFromText(text: string): Config;
+    /**
+     * addConfig adds a new section->key:value to the configuration.
+     */
+    private addConfig;
+    private parse;
+    private parseBuffer;
+    private write;
+    getBool(key: string): boolean;
+    getInt(key: string): number;
+    getFloat(key: string): number;
+    getString(key: string): string;
+    getStrings(key: string): string[];
+    set(key: string, value: string): void;
+    get(key: string): string;
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,170 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+const fs_1 = require("fs");
+class Config {
+    constructor() {
+        this.data = new Map();
+    }
+    /**
+     * newConfig create an empty configuration representation from file.
+     *
+     * @param confName the path of the model file.
+     * @return the constructor of Config.
+     */
+    static newConfig(confName) {
+        const config = new Config();
+        config.parse(confName);
+        return config;
+    }
+    /**
+     * newConfigFromText create an empty configuration representation from text.
+     *
+     * @param text the model text.
+     * @return the constructor of Config.
+     */
+    static newConfigFromText(text) {
+        const config = new Config();
+        config.parseBuffer(Buffer.from(text));
+        return config;
+    }
+    /**
+     * addConfig adds a new section->key:value to the configuration.
+     */
+    addConfig(section, option, value) {
+        if (section === '') {
+            section = Config.DEFAULT_SECTION;
+        }
+        const hasKey = this.data.has(section);
+        if (!hasKey) {
+            this.data.set(section, new Map());
+        }
+        const item = this.data.get(section);
+        if (item) {
+            item.set(option, value);
+            return item.has(option);
+        }
+        else {
+            return false;
+        }
+    }
+    parse(path) {
+        const buf = fs_1.readFileSync(path);
+        this.parseBuffer(buf);
+    }
+    parseBuffer(buf) {
+        const lines = buf.toString().split('\n');
+        const linesCount = lines.length;
+        let section = '';
+        let currentLine = '';
+        lines.forEach((n, index) => {
+            const line = n.trim();
+            const lineNumber = index + 1;
+            if (!line) {
+                return;
+            }
+            if (line.startsWith(Config.DEFAULT_COMMENT) || line.startsWith(Config.DEFAULT_COMMENT_SEM)) {
+                return;
+            }
+            else if (line.startsWith('[') && line.endsWith(']')) {
+                if (currentLine.length !== 0) {
+                    this.write(section, lineNumber - 1, currentLine);
+                    currentLine = '';
+                }
+                section = line.substring(1, line.length - 1);
+            }
+            else {
+                let shouldWrite = false;
+                if (line.includes(Config.DEFAULT_MULTI_LINE_SEPARATOR)) {
+                    currentLine += line.substring(0, line.length - 1).trim();
+                    // when the last line has a "\" string
+                    if (lineNumber + 1 === linesCount) {
+                        shouldWrite = true;
+                    }
+                }
+                else {
+                    currentLine += line;
+                    shouldWrite = true;
+                }
+                if (shouldWrite) {
+                    this.write(section, lineNumber, currentLine);
+                    currentLine = '';
+                }
+            }
+        });
+    }
+    write(section, lineNum, line) {
+        const equalIndex = line.indexOf('=');
+        if (equalIndex === -1) {
+            throw new Error(`parse the content error : line ${lineNum}`);
+        }
+        const key = line.substring(0, equalIndex);
+        const value = line.substring(equalIndex + 1);
+        this.addConfig(section, key.trim(), value.trim());
+    }
+    getBool(key) {
+        return !!this.get(key);
+    }
+    getInt(key) {
+        return Number.parseInt(this.get(key), 10);
+    }
+    getFloat(key) {
+        return Number.parseFloat(this.get(key));
+    }
+    getString(key) {
+        return this.get(key);
+    }
+    getStrings(key) {
+        const v = this.get(key);
+        return v.split(',');
+    }
+    set(key, value) {
+        if (!key) {
+            throw new Error('key is empty');
+        }
+        let section = '';
+        let option;
+        const keys = key.toLowerCase().split('::');
+        if (keys.length >= 2) {
+            section = keys[0];
+            option = keys[1];
+        }
+        else {
+            option = keys[0];
+        }
+        this.addConfig(section, option, value);
+    }
+    get(key) {
+        let section;
+        let option;
+        const keys = key.toLowerCase().split('::');
+        if (keys.length >= 2) {
+            section = keys[0];
+            option = keys[1];
+        }
+        else {
+            section = Config.DEFAULT_SECTION;
+            option = keys[0];
+        }
+        const item = this.data.get(section);
+        const itemChild = item && item.get(option);
+        return itemChild ? itemChild : '';
+    }
+}
+exports.Config = Config;
+Config.DEFAULT_SECTION = 'default';
+Config.DEFAULT_COMMENT = '#';
+Config.DEFAULT_COMMENT_SEM = ';';
+Config.DEFAULT_MULTI_LINE_SEPARATOR = '\\';

--- a/lib/coreEnforcer.d.ts
+++ b/lib/coreEnforcer.d.ts
@@ -1,0 +1,134 @@
+import { Effector } from './effect';
+import { FunctionMap, Model } from './model';
+import { Adapter, Filter, FilteredAdapter, Watcher } from './persist';
+import { RoleManager } from './rbac';
+/**
+ * CoreEnforcer defines the core functionality of an enforcer.
+ */
+export declare class CoreEnforcer {
+    protected modelPath: string;
+    protected model: Model;
+    protected fm: FunctionMap;
+    private eft;
+    protected adapter: FilteredAdapter | Adapter;
+    protected watcher: Watcher | null;
+    protected rm: RoleManager;
+    private enabled;
+    protected autoSave: boolean;
+    protected autoBuildRoleLinks: boolean;
+    initialize(): void;
+    /**
+     * loadModel reloads the model from the model CONF file.
+     * Because the policy is attached to a model,
+     * so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
+     */
+    loadModel(): void;
+    /**
+     * getModel gets the current model.
+     *
+     * @return the model of the enforcer.
+     */
+    getModel(): Model;
+    /**
+     * setModel sets the current model.
+     *
+     * @param m the model.
+     */
+    setModel(m: Model): void;
+    /**
+     * getAdapter gets the current adapter.
+     *
+     * @return the adapter of the enforcer.
+     */
+    getAdapter(): Adapter;
+    /**
+     * setAdapter sets the current adapter.
+     *
+     * @param adapter the adapter.
+     */
+    setAdapter(adapter: Adapter): void;
+    /**
+     * setWatcher sets the current watcher.
+     *
+     * @param watcher the watcher.
+     */
+    setWatcher(watcher: Watcher): void;
+    /**
+     * setRoleManager sets the current role manager.
+     *
+     * @param rm the role manager.
+     */
+    setRoleManager(rm: RoleManager): void;
+    /**
+     * setEffector sets the current effector.
+     *
+     * @param eft the effector.
+     */
+    setEffector(eft: Effector): void;
+    /**
+     * clearPolicy clears all policy.
+     */
+    clearPolicy(): void;
+    /**
+     * loadPolicy reloads the policy from file/database.
+     */
+    loadPolicy(): Promise<void>;
+    /**
+     * loadFilteredPolicy reloads a filtered policy from file/database.
+     *
+     * @param filter the filter used to specify which type of policy should be loaded.
+     */
+    loadFilteredPolicy(filter: Filter): Promise<boolean>;
+    /**
+     * isFiltered returns true if the loaded policy has been filtered.
+     *
+     * @return if the loaded policy has been filtered.
+     */
+    isFiltered(): boolean;
+    /**
+     * savePolicy saves the current policy (usually after changed with
+     * Casbin API) back to file/database.
+     */
+    savePolicy(): Promise<boolean>;
+    /**
+     * enableEnforce changes the enforcing state of Casbin, when Casbin is
+     * disabled, all access will be allowed by the enforce() function.
+     *
+     * @param enable whether to enable the enforcer.
+     */
+    enableEnforce(enable: boolean): void;
+    /**
+     * enableLog changes whether to print Casbin log to the standard output.
+     *
+     * @param enable whether to enable Casbin's log.
+     */
+    enableLog(enable: boolean): void;
+    /**
+     * enableAutoSave controls whether to save a policy rule automatically to
+     * the adapter when it is added or removed.
+     *
+     * @param autoSave whether to enable the AutoSave feature.
+     */
+    enableAutoSave(autoSave: boolean): void;
+    /**
+     * enableAutoBuildRoleLinks controls whether to save a policy rule
+     * automatically to the adapter when it is added or removed.
+     *
+     * @param autoBuildRoleLinks whether to automatically build the role links.
+     */
+    enableAutoBuildRoleLinks(autoBuildRoleLinks: boolean): void;
+    /**
+     * buildRoleLinks manually rebuild the
+     * role inheritance relations.
+     */
+    buildRoleLinks(): void;
+    /**
+     * enforce decides whether a "subject" can access a "object" with
+     * the operation "action", input parameters are usually: (sub, obj, act).
+     *
+     * @param rvals the request needs to be mediated, usually an array
+     *              of strings, can be class instances if ABAC is used.
+     * @return whether to allow the request.
+     */
+    enforce(...rvals: any[]): boolean;
+}

--- a/lib/coreEnforcer.js
+++ b/lib/coreEnforcer.js
@@ -1,0 +1,358 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const expression_eval_1 = require("expression-eval");
+const _ = require("lodash");
+const effect_1 = require("./effect");
+const model_1 = require("./model");
+const rbac_1 = require("./rbac");
+const util_1 = require("./util");
+const casbin_1 = require("./casbin");
+const log_1 = require("./log");
+/**
+ * CoreEnforcer defines the core functionality of an enforcer.
+ */
+class CoreEnforcer {
+    constructor() {
+        this.watcher = null;
+    }
+    initialize() {
+        this.rm = new rbac_1.DefaultRoleManager(10);
+        this.eft = new effect_1.DefaultEffector();
+        this.watcher = null;
+        this.enabled = true;
+        this.autoSave = true;
+        this.autoBuildRoleLinks = true;
+    }
+    /**
+     * loadModel reloads the model from the model CONF file.
+     * Because the policy is attached to a model,
+     * so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
+     */
+    loadModel() {
+        this.model = casbin_1.newModel();
+        this.model.loadModel(this.modelPath);
+        this.model.printModel();
+        this.fm = model_1.FunctionMap.loadFunctionMap();
+    }
+    /**
+     * getModel gets the current model.
+     *
+     * @return the model of the enforcer.
+     */
+    getModel() {
+        return this.model;
+    }
+    /**
+     * setModel sets the current model.
+     *
+     * @param m the model.
+     */
+    setModel(m) {
+        this.model = m;
+        this.fm = model_1.FunctionMap.loadFunctionMap();
+    }
+    /**
+     * getAdapter gets the current adapter.
+     *
+     * @return the adapter of the enforcer.
+     */
+    getAdapter() {
+        return this.adapter;
+    }
+    /**
+     * setAdapter sets the current adapter.
+     *
+     * @param adapter the adapter.
+     */
+    setAdapter(adapter) {
+        this.adapter = adapter;
+    }
+    /**
+     * setWatcher sets the current watcher.
+     *
+     * @param watcher the watcher.
+     */
+    setWatcher(watcher) {
+        this.watcher = watcher;
+        watcher.setUpdateCallback(() => __awaiter(this, void 0, void 0, function* () { return yield this.loadPolicy(); }));
+    }
+    /**
+     * setRoleManager sets the current role manager.
+     *
+     * @param rm the role manager.
+     */
+    setRoleManager(rm) {
+        this.rm = rm;
+    }
+    /**
+     * setEffector sets the current effector.
+     *
+     * @param eft the effector.
+     */
+    setEffector(eft) {
+        this.eft = eft;
+    }
+    /**
+     * clearPolicy clears all policy.
+     */
+    clearPolicy() {
+        this.model.clearPolicy();
+    }
+    /**
+     * loadPolicy reloads the policy from file/database.
+     */
+    loadPolicy() {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.model.clearPolicy();
+            yield this.adapter.loadPolicy(this.model);
+            this.model.printPolicy();
+            if (this.autoBuildRoleLinks) {
+                this.buildRoleLinks();
+            }
+        });
+    }
+    /**
+     * loadFilteredPolicy reloads a filtered policy from file/database.
+     *
+     * @param filter the filter used to specify which type of policy should be loaded.
+     */
+    loadFilteredPolicy(filter) {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.model.clearPolicy();
+            yield this.adapter.loadFilteredPolicy(this.model, filter);
+            this.model.printPolicy();
+            if (this.autoBuildRoleLinks) {
+                this.buildRoleLinks();
+            }
+            return true;
+        });
+    }
+    /**
+     * isFiltered returns true if the loaded policy has been filtered.
+     *
+     * @return if the loaded policy has been filtered.
+     */
+    isFiltered() {
+        if (this.adapter.isFiltered) {
+            return this.adapter.isFiltered();
+        }
+        return false;
+    }
+    /**
+     * savePolicy saves the current policy (usually after changed with
+     * Casbin API) back to file/database.
+     */
+    savePolicy() {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (this.isFiltered()) {
+                throw new Error('cannot save a filtered policy');
+            }
+            const flag = yield this.adapter.savePolicy(this.model);
+            if (!flag) {
+                return false;
+            }
+            if (this.watcher) {
+                return yield this.watcher.update();
+            }
+            return true;
+        });
+    }
+    /**
+     * enableEnforce changes the enforcing state of Casbin, when Casbin is
+     * disabled, all access will be allowed by the enforce() function.
+     *
+     * @param enable whether to enable the enforcer.
+     */
+    enableEnforce(enable) {
+        this.enabled = enable;
+    }
+    /**
+     * enableLog changes whether to print Casbin log to the standard output.
+     *
+     * @param enable whether to enable Casbin's log.
+     */
+    enableLog(enable) {
+        log_1.getLogger().enableLog(enable);
+    }
+    /**
+     * enableAutoSave controls whether to save a policy rule automatically to
+     * the adapter when it is added or removed.
+     *
+     * @param autoSave whether to enable the AutoSave feature.
+     */
+    enableAutoSave(autoSave) {
+        this.autoSave = autoSave;
+    }
+    /**
+     * enableAutoBuildRoleLinks controls whether to save a policy rule
+     * automatically to the adapter when it is added or removed.
+     *
+     * @param autoBuildRoleLinks whether to automatically build the role links.
+     */
+    enableAutoBuildRoleLinks(autoBuildRoleLinks) {
+        this.autoBuildRoleLinks = autoBuildRoleLinks;
+    }
+    /**
+     * buildRoleLinks manually rebuild the
+     * role inheritance relations.
+     */
+    buildRoleLinks() {
+        // error intentionally ignored
+        this.rm.clear();
+        this.model.buildRoleLinks(this.rm);
+    }
+    /**
+     * enforce decides whether a "subject" can access a "object" with
+     * the operation "action", input parameters are usually: (sub, obj, act).
+     *
+     * @param rvals the request needs to be mediated, usually an array
+     *              of strings, can be class instances if ABAC is used.
+     * @return whether to allow the request.
+     */
+    enforce(...rvals) {
+        if (!this.enabled) {
+            return true;
+        }
+        const functions = {};
+        this.fm.getFunctions().forEach((value, key) => {
+            functions[key] = value;
+        });
+        const astMap = this.model.model.get('g');
+        if (astMap) {
+            astMap.forEach((value, key) => {
+                const rm = value.rm;
+                functions[key] = util_1.generateGFunction(rm);
+            });
+        }
+        // @ts-ignore
+        const expString = this.model.model.get('m').get('m').value;
+        if (!expString) {
+            throw new Error('model is undefined');
+        }
+        const expression = expression_eval_1.compile(expString);
+        let policyEffects;
+        let matcherResults;
+        // @ts-ignore
+        const policyLen = this.model.model.get('p').get('p').policy.length;
+        if (policyLen !== 0) {
+            policyEffects = new Array(policyLen);
+            matcherResults = new Array(policyLen);
+            for (let i = 0; i < policyLen; i++) {
+                // @ts-ignore
+                const pvals = this.model.model.get('p').get('p').policy[i];
+                // logPrint('Policy Rule: ', pvals);
+                const parameters = {};
+                // @ts-ignore
+                this.model.model.get('r').get('r').tokens.forEach((token, j) => {
+                    parameters[token] = rvals[j];
+                });
+                // @ts-ignore
+                this.model.model.get('p').get('p').tokens.forEach((token, j) => {
+                    parameters[token] = pvals[j];
+                });
+                const result = expression(Object.assign(Object.assign({}, parameters), functions));
+                switch (typeof result) {
+                    case 'boolean':
+                        if (!result) {
+                            policyEffects[i] = effect_1.Effect.Indeterminate;
+                            continue;
+                        }
+                        break;
+                    case 'number':
+                        if (result === 0) {
+                            policyEffects[i] = effect_1.Effect.Indeterminate;
+                            continue;
+                        }
+                        else {
+                            matcherResults[i] = result;
+                        }
+                        break;
+                    default:
+                        throw new Error('matcher result should be boolean or number');
+                }
+                if (_.has(parameters, 'p_eft')) {
+                    const eft = _.get(parameters, 'p_eft');
+                    if (eft === 'allow') {
+                        policyEffects[i] = effect_1.Effect.Allow;
+                    }
+                    else if (eft === 'deny') {
+                        policyEffects[i] = effect_1.Effect.Deny;
+                    }
+                    else {
+                        policyEffects[i] = effect_1.Effect.Indeterminate;
+                    }
+                }
+                else {
+                    policyEffects[i] = effect_1.Effect.Allow;
+                }
+                // @ts-ignore
+                if (this.model.model.get('e').get('e').value === 'priority(p_eft) || deny') {
+                    break;
+                }
+            }
+        }
+        else {
+            policyEffects = new Array(1);
+            matcherResults = new Array(1);
+            const parameters = {};
+            // @ts-ignore
+            this.model.model.get('r').get('r').tokens.forEach((token, j) => {
+                parameters[token] = rvals[j];
+            });
+            // @ts-ignore
+            this.model.model.get('p').get('p').tokens.forEach((token) => {
+                parameters[token] = '';
+            });
+            const result = expression(Object.assign(Object.assign({}, parameters), functions));
+            // logPrint(`Result: ${result}`);
+            if (result) {
+                policyEffects[0] = effect_1.Effect.Allow;
+            }
+            else {
+                policyEffects[0] = effect_1.Effect.Indeterminate;
+            }
+        }
+        // logPrint(`Rule Results: ${policyEffects}`);
+        // @ts-ignore
+        const res = this.eft.mergeEffects(this.model.model.get('e').get('e').value, policyEffects, matcherResults);
+        // only generate the request --> result string if the message
+        // is going to be logged.
+        if (log_1.getLogger().isEnable()) {
+            let reqStr = 'Request: ';
+            for (let i = 0; i < rvals.length; i++) {
+                if (i !== rvals.length - 1) {
+                    reqStr += `${rvals[i]}, `;
+                }
+                else {
+                    reqStr += rvals[i];
+                }
+            }
+            reqStr += ` ---> ${res}`;
+            log_1.logPrint(reqStr);
+        }
+        return res;
+    }
+}
+exports.CoreEnforcer = CoreEnforcer;

--- a/lib/effect/defaultEffector.d.ts
+++ b/lib/effect/defaultEffector.d.ts
@@ -1,0 +1,14 @@
+import { Effect, Effector } from './effector';
+/**
+ * DefaultEffector is default effector for Casbin.
+ */
+export declare class DefaultEffector implements Effector {
+    /**
+     * mergeEffects merges all matching results collected by the enforcer into a single decision.
+     * @param {string} expr
+     * @param {Effect[]} effects
+     * @param {number[]} results
+     * @returns {boolean}
+     */
+    mergeEffects(expr: string, effects: Effect[], results: number[]): boolean;
+}

--- a/lib/effect/defaultEffector.js
+++ b/lib/effect/defaultEffector.js
@@ -1,0 +1,57 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const effector_1 = require("./effector");
+/**
+ * DefaultEffector is default effector for Casbin.
+ */
+class DefaultEffector {
+    /**
+     * mergeEffects merges all matching results collected by the enforcer into a single decision.
+     * @param {string} expr
+     * @param {Effect[]} effects
+     * @param {number[]} results
+     * @returns {boolean}
+     */
+    mergeEffects(expr, effects, results) {
+        let result = false;
+        if (expr === 'some(where (p_eft == allow))') {
+            result = effects.some(n => n === effector_1.Effect.Allow);
+        }
+        else if (expr === '!some(where (p_eft == deny))') {
+            result = !effects.some(n => n === effector_1.Effect.Deny);
+        }
+        else if (expr === 'some(where (p_eft == allow)) && !some(where (p_eft == deny))') {
+            result = false;
+            for (const eft of effects) {
+                if (eft === effector_1.Effect.Allow) {
+                    result = true;
+                }
+                else if (eft === effector_1.Effect.Deny) {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        else if (expr === 'priority(p_eft) || deny') {
+            result = effects.some(n => n !== effector_1.Effect.Indeterminate && n === effector_1.Effect.Allow);
+        }
+        else {
+            throw new Error('unsupported effect');
+        }
+        return result;
+    }
+}
+exports.DefaultEffector = DefaultEffector;

--- a/lib/effect/effector.d.ts
+++ b/lib/effect/effector.d.ts
@@ -1,0 +1,8 @@
+export declare enum Effect {
+    Allow = 1,
+    Indeterminate = 2,
+    Deny = 3
+}
+export interface Effector {
+    mergeEffects(expr: string, effects: Effect[], results: number[]): boolean;
+}

--- a/lib/effect/effector.js
+++ b/lib/effect/effector.js
@@ -1,0 +1,23 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+// Effect is the result for a policy rule.
+// Values for policy effect.
+var Effect;
+(function (Effect) {
+    Effect[Effect["Allow"] = 1] = "Allow";
+    Effect[Effect["Indeterminate"] = 2] = "Indeterminate";
+    Effect[Effect["Deny"] = 3] = "Deny";
+})(Effect = exports.Effect || (exports.Effect = {}));

--- a/lib/effect/index.d.ts
+++ b/lib/effect/index.d.ts
@@ -1,0 +1,2 @@
+export * from './defaultEffector';
+export * from './effector';

--- a/lib/effect/index.js
+++ b/lib/effect/index.js
@@ -1,0 +1,20 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./defaultEffector"));
+__export(require("./effector"));

--- a/lib/enforcer.d.ts
+++ b/lib/enforcer.d.ts
@@ -1,0 +1,167 @@
+import { ManagementEnforcer } from './managementEnforcer';
+import { Model } from './model';
+import { Adapter } from './persist';
+/**
+ * Enforcer = ManagementEnforcer + RBAC API.
+ */
+export declare class Enforcer extends ManagementEnforcer {
+    /**
+     * initWithFile initializes an enforcer with a model file and a policy file.
+     * @param modelPath model file path
+     * @param policyPath policy file path
+     */
+    initWithFile(modelPath: string, policyPath: string): Promise<void>;
+    /**
+     * initWithAdapter initializes an enforcer with a database adapter.
+     * @param modelPath model file path
+     * @param adapter current adapter instance
+     */
+    initWithAdapter(modelPath: string, adapter: Adapter, filter?: any): Promise<void>;
+    /**
+     * initWithModelAndAdapter initializes an enforcer with a model and a database adapter.
+     * @param m model instance
+     * @param adapter current adapter instance
+     */
+    initWithModelAndAdapter(m: Model, adapter: Adapter, filter?: any): Promise<void>;
+    /**
+     * getRolesForUser gets the roles that a user has.
+     *
+     * @param name the user.
+     * @param domain the domain.
+     * @return the roles that the user has.
+     */
+    getRolesForUser(name: string, domain?: string): string[];
+    /**
+     * getUsersForRole gets the users that has a role.
+     *
+     * @param name the role.
+     * @param domain the domain.
+     * @return the users that has the role.
+     */
+    getUsersForRole(name: string, domain?: string): string[];
+    /**
+     * hasRoleForUser determines whether a user has a role.
+     *
+     * @param name the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return whether the user has the role.
+     */
+    hasRoleForUser(name: string, role: string, domain?: string): boolean;
+    /**
+     * addRoleForUser adds a role for a user.
+     * Returns false if the user already has the role (aka not affected).
+     *
+     * @param user the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    addRoleForUser(user: string, role: string, domain?: string): Promise<boolean>;
+    /**
+     * deleteRoleForUser deletes a role for a user.
+     * Returns false if the user does not have the role (aka not affected).
+     *
+     * @param user the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    deleteRoleForUser(user: string, role: string, domain?: string): Promise<boolean>;
+    /**
+     * deleteRolesForUser deletes all roles for a user.
+     * Returns false if the user does not have any roles (aka not affected).
+     *
+     * @param user the user.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    deleteRolesForUser(user: string, domain?: string): Promise<boolean>;
+    /**
+     * deleteUser deletes a user.
+     * Returns false if the user does not exist (aka not affected).
+     *
+     * @param user the user.
+     * @return succeeds or not.
+     */
+    deleteUser(user: string): Promise<boolean>;
+    /**
+     * deleteRole deletes a role.
+     *
+     * @param role the role.
+     * @return succeeds or not.
+     */
+    deleteRole(role: string): Promise<boolean>;
+    /**
+     * deletePermission deletes a permission.
+     * Returns false if the permission does not exist (aka not affected).
+     *
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    deletePermission(...permission: string[]): Promise<boolean>;
+    /**
+     * addPermissionForUser adds a permission for a user or role.
+     * Returns false if the user or role already has the permission (aka not affected).
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    addPermissionForUser(user: string, ...permission: string[]): Promise<boolean>;
+    /**
+     * deletePermissionForUser deletes a permission for a user or role.
+     * Returns false if the user or role does not have the permission (aka not affected).
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    deletePermissionForUser(user: string, ...permission: string[]): Promise<boolean>;
+    /**
+     * deletePermissionsForUser deletes permissions for a user or role.
+     * Returns false if the user or role does not have any permissions (aka not affected).
+     *
+     * @param user the user.
+     * @return succeeds or not.
+     */
+    deletePermissionsForUser(user: string): Promise<boolean>;
+    /**
+     * getPermissionsForUser gets permissions for a user or role.
+     *
+     * @param user the user.
+     * @return the permissions, a permission is usually like (obj, act). It is actually the rule without the subject.
+     */
+    getPermissionsForUser(user: string): string[][];
+    /**
+     * hasPermissionForUser determines whether a user has a permission.
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return whether the user has the permission.
+     */
+    hasPermissionForUser(user: string, ...permission: string[]): boolean;
+    /**
+     * getImplicitRolesForUser gets implicit roles that a user has.
+     * Compared to getRolesForUser(), this function retrieves indirect roles besides direct roles.
+     * For example:
+     * g, alice, role:admin
+     * g, role:admin, role:user
+     *
+     * getRolesForUser("alice") can only get: ["role:admin"].
+     * But getImplicitRolesForUser("alice") will get: ["role:admin", "role:user"].
+     */
+    getImplicitRolesForUser(name: string, ...domain: string[]): string[];
+    /**
+     * getImplicitPermissionsForUser gets implicit permissions for a user or role.
+     * Compared to getPermissionsForUser(), this function retrieves permissions for inherited roles.
+     * For example:
+     * p, admin, data1, read
+     * p, alice, data2, read
+     * g, alice, admin
+     *
+     * getPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
+     * But getImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+     */
+    getImplicitPermissionsForUser(user: string, ...domain: string[]): Promise<string[][]>;
+}

--- a/lib/enforcer.js
+++ b/lib/enforcer.js
@@ -1,0 +1,333 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const managementEnforcer_1 = require("./managementEnforcer");
+const model_1 = require("./model");
+const persist_1 = require("./persist");
+const casbin_1 = require("./casbin");
+/**
+ * Enforcer = ManagementEnforcer + RBAC API.
+ */
+class Enforcer extends managementEnforcer_1.ManagementEnforcer {
+    /**
+     * initWithFile initializes an enforcer with a model file and a policy file.
+     * @param modelPath model file path
+     * @param policyPath policy file path
+     */
+    initWithFile(modelPath, policyPath) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const a = new persist_1.FileAdapter(policyPath);
+            yield this.initWithAdapter(modelPath, a);
+        });
+    }
+    /**
+     * initWithAdapter initializes an enforcer with a database adapter.
+     * @param modelPath model file path
+     * @param adapter current adapter instance
+     */
+    initWithAdapter(modelPath, adapter, filter = null) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const m = casbin_1.newModel(modelPath, '');
+            yield this.initWithModelAndAdapter(m, adapter, filter);
+            this.modelPath = modelPath;
+        });
+    }
+    /**
+     * initWithModelAndAdapter initializes an enforcer with a model and a database adapter.
+     * @param m model instance
+     * @param adapter current adapter instance
+     */
+    initWithModelAndAdapter(m, adapter, filter = null) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (adapter) {
+                this.adapter = adapter;
+            }
+            this.model = m;
+            this.model.printModel();
+            this.fm = model_1.FunctionMap.loadFunctionMap();
+            this.initialize();
+            if (this.adapter && filter) {
+                // error intentionally ignored
+                yield this.loadFilteredPolicy(filter);
+            }
+            if (this.adapter && !filter) {
+                // error intentionally ignored
+                yield this.loadPolicy();
+            }
+        });
+    }
+    /**
+     * getRolesForUser gets the roles that a user has.
+     *
+     * @param name the user.
+     * @param domain the domain.
+     * @return the roles that the user has.
+     */
+    getRolesForUser(name, domain) {
+        // @ts-ignore
+        const rm = this.model.model.get('g').get('g').rm;
+        if (domain == null) {
+            return rm.getRoles(name);
+        }
+        else {
+            return rm.getRoles(name, domain);
+        }
+    }
+    /**
+     * getUsersForRole gets the users that has a role.
+     *
+     * @param name the role.
+     * @param domain the domain.
+     * @return the users that has the role.
+     */
+    getUsersForRole(name, domain) {
+        // @ts-ignore
+        const rm = this.model.model.get('g').get('g').rm;
+        if (domain == null) {
+            return rm.getUsers(name);
+        }
+        else {
+            return rm.getUsers(name, domain);
+        }
+    }
+    /**
+     * hasRoleForUser determines whether a user has a role.
+     *
+     * @param name the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return whether the user has the role.
+     */
+    hasRoleForUser(name, role, domain) {
+        const roles = this.getRolesForUser(name, domain);
+        let hasRole = false;
+        for (const r of roles) {
+            if (r === role) {
+                hasRole = true;
+                break;
+            }
+        }
+        return hasRole;
+    }
+    /**
+     * addRoleForUser adds a role for a user.
+     * Returns false if the user already has the role (aka not affected).
+     *
+     * @param user the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    addRoleForUser(user, role, domain) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (domain == null) {
+                return yield this.addGroupingPolicy(user, role);
+            }
+            else {
+                return yield this.addGroupingPolicy(user, role, domain);
+            }
+        });
+    }
+    /**
+     * deleteRoleForUser deletes a role for a user.
+     * Returns false if the user does not have the role (aka not affected).
+     *
+     * @param user the user.
+     * @param role the role.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    deleteRoleForUser(user, role, domain) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (domain == null) {
+                return yield this.removeGroupingPolicy(user, role);
+            }
+            else {
+                return yield this.removeGroupingPolicy(user, role, domain);
+            }
+        });
+    }
+    /**
+     * deleteRolesForUser deletes all roles for a user.
+     * Returns false if the user does not have any roles (aka not affected).
+     *
+     * @param user the user.
+     * @param domain the domain.
+     * @return succeeds or not.
+     */
+    deleteRolesForUser(user, domain) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (domain == null) {
+                return yield this.removeFilteredGroupingPolicy(0, user);
+            }
+            else {
+                return yield this.removeFilteredGroupingPolicy(0, user, '', domain);
+            }
+        });
+    }
+    /**
+     * deleteUser deletes a user.
+     * Returns false if the user does not exist (aka not affected).
+     *
+     * @param user the user.
+     * @return succeeds or not.
+     */
+    deleteUser(user) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredGroupingPolicy(0, user);
+        });
+    }
+    /**
+     * deleteRole deletes a role.
+     *
+     * @param role the role.
+     * @return succeeds or not.
+     */
+    deleteRole(role) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const res1 = yield this.removeFilteredGroupingPolicy(1, role);
+            const res2 = yield this.removeFilteredPolicy(0, role);
+            return res1 || res2;
+        });
+    }
+    /**
+     * deletePermission deletes a permission.
+     * Returns false if the permission does not exist (aka not affected).
+     *
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    deletePermission(...permission) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredPolicy(1, ...permission);
+        });
+    }
+    /**
+     * addPermissionForUser adds a permission for a user or role.
+     * Returns false if the user or role already has the permission (aka not affected).
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    addPermissionForUser(user, ...permission) {
+        return __awaiter(this, void 0, void 0, function* () {
+            permission.unshift(user);
+            return yield this.addPolicy(...permission);
+        });
+    }
+    /**
+     * deletePermissionForUser deletes a permission for a user or role.
+     * Returns false if the user or role does not have the permission (aka not affected).
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return succeeds or not.
+     */
+    deletePermissionForUser(user, ...permission) {
+        return __awaiter(this, void 0, void 0, function* () {
+            permission.unshift(user);
+            return yield this.removePolicy(...permission);
+        });
+    }
+    /**
+     * deletePermissionsForUser deletes permissions for a user or role.
+     * Returns false if the user or role does not have any permissions (aka not affected).
+     *
+     * @param user the user.
+     * @return succeeds or not.
+     */
+    deletePermissionsForUser(user) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredPolicy(0, user);
+        });
+    }
+    /**
+     * getPermissionsForUser gets permissions for a user or role.
+     *
+     * @param user the user.
+     * @return the permissions, a permission is usually like (obj, act). It is actually the rule without the subject.
+     */
+    getPermissionsForUser(user) {
+        return this.getFilteredPolicy(0, user);
+    }
+    /**
+     * hasPermissionForUser determines whether a user has a permission.
+     *
+     * @param user the user.
+     * @param permission the permission, usually be (obj, act). It is actually the rule without the subject.
+     * @return whether the user has the permission.
+     */
+    hasPermissionForUser(user, ...permission) {
+        permission.unshift(user);
+        return this.hasPolicy(...permission);
+    }
+    /**
+     * getImplicitRolesForUser gets implicit roles that a user has.
+     * Compared to getRolesForUser(), this function retrieves indirect roles besides direct roles.
+     * For example:
+     * g, alice, role:admin
+     * g, role:admin, role:user
+     *
+     * getRolesForUser("alice") can only get: ["role:admin"].
+     * But getImplicitRolesForUser("alice") will get: ["role:admin", "role:user"].
+     */
+    getImplicitRolesForUser(name, ...domain) {
+        const res = [];
+        const roles = this.rm.getRoles(name, ...domain);
+        res.push(...roles);
+        roles.forEach(n => {
+            res.push(...this.getImplicitRolesForUser(n, ...domain));
+        });
+        return res;
+    }
+    /**
+     * getImplicitPermissionsForUser gets implicit permissions for a user or role.
+     * Compared to getPermissionsForUser(), this function retrieves permissions for inherited roles.
+     * For example:
+     * p, admin, data1, read
+     * p, alice, data2, read
+     * g, alice, admin
+     *
+     * getPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
+     * But getImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
+     */
+    getImplicitPermissionsForUser(user, ...domain) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const roles = [user, ...(yield this.getImplicitRolesForUser(user, ...domain))];
+            const res = [];
+            const withDomain = domain && domain.length !== 0;
+            roles.forEach(n => {
+                if (withDomain) {
+                    res.push(...this.getFilteredPolicy(0, n, ...domain));
+                }
+                else {
+                    res.push(...this.getPermissionsForUser(n));
+                }
+            });
+            return res;
+        });
+    }
+}
+exports.Enforcer = Enforcer;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,10 @@
+import * as Util from './util';
+export * from './config';
+export * from './enforcer';
+export * from './effect';
+export * from './model';
+export * from './persist';
+export * from './rbac';
+export * from './casbin';
+export * from './log';
+export { Util };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,28 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+const Util = require("./util");
+exports.Util = Util;
+__export(require("./config"));
+__export(require("./enforcer"));
+__export(require("./effect"));
+__export(require("./model"));
+__export(require("./persist"));
+__export(require("./rbac"));
+__export(require("./casbin"));
+__export(require("./log"));

--- a/lib/internalEnforcer.d.ts
+++ b/lib/internalEnforcer.d.ts
@@ -1,0 +1,18 @@
+import { CoreEnforcer } from './coreEnforcer';
+/**
+ * InternalEnforcer = CoreEnforcer + Internal API.
+ */
+export declare class InternalEnforcer extends CoreEnforcer {
+    /**
+     * addPolicyInternal adds a rule to the current policy.
+     */
+    addPolicyInternal(sec: string, ptype: string, rule: string[]): Promise<boolean>;
+    /**
+     * removePolicyInternal removes a rule from the current policy.
+     */
+    removePolicyInternal(sec: string, ptype: string, rule: string[]): Promise<boolean>;
+    /**
+     * removeFilteredPolicyInternal removes rules based on field filters from the current policy.
+     */
+    removeFilteredPolicyInternal(sec: string, ptype: string, fieldIndex: number, fieldValues: string[]): Promise<boolean>;
+}

--- a/lib/internalEnforcer.js
+++ b/lib/internalEnforcer.js
@@ -1,0 +1,109 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const coreEnforcer_1 = require("./coreEnforcer");
+/**
+ * InternalEnforcer = CoreEnforcer + Internal API.
+ */
+class InternalEnforcer extends coreEnforcer_1.CoreEnforcer {
+    /**
+     * addPolicyInternal adds a rule to the current policy.
+     */
+    addPolicyInternal(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleAdded = this.model.addPolicy(sec, ptype, rule);
+            if (!ruleAdded) {
+                return ruleAdded;
+            }
+            if (this.adapter && this.autoSave) {
+                try {
+                    yield this.adapter.addPolicy(sec, ptype, rule);
+                }
+                catch (e) {
+                    if (e.message !== 'not implemented') {
+                        throw e;
+                    }
+                }
+                if (this.watcher) {
+                    // error intentionally ignored
+                    this.watcher.update();
+                }
+            }
+            return ruleAdded;
+        });
+    }
+    /**
+     * removePolicyInternal removes a rule from the current policy.
+     */
+    removePolicyInternal(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleRemoved = this.model.removePolicy(sec, ptype, rule);
+            if (!ruleRemoved) {
+                return ruleRemoved;
+            }
+            if (this.adapter && this.autoSave) {
+                try {
+                    yield this.adapter.removePolicy(sec, ptype, rule);
+                }
+                catch (e) {
+                    if (e.message !== 'not implemented') {
+                        throw e;
+                    }
+                }
+                if (this.watcher) {
+                    // error intentionally ignored
+                    this.watcher.update();
+                }
+            }
+            return ruleRemoved;
+        });
+    }
+    /**
+     * removeFilteredPolicyInternal removes rules based on field filters from the current policy.
+     */
+    removeFilteredPolicyInternal(sec, ptype, fieldIndex, fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleRemoved = this.model.removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);
+            if (!ruleRemoved) {
+                return ruleRemoved;
+            }
+            if (this.adapter && this.autoSave) {
+                try {
+                    yield this.adapter.removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues);
+                }
+                catch (e) {
+                    if (e.message !== 'not implemented') {
+                        throw e;
+                    }
+                }
+                if (this.watcher) {
+                    // error intentionally ignored
+                    this.watcher.update();
+                }
+            }
+            return ruleRemoved;
+        });
+    }
+}
+exports.InternalEnforcer = InternalEnforcer;

--- a/lib/log/defaultLogger.d.ts
+++ b/lib/log/defaultLogger.d.ts
@@ -1,0 +1,8 @@
+import { Logger } from './logger';
+export declare class DefaultLogger implements Logger {
+    private enable;
+    enableLog(enable: boolean): void;
+    isEnable(): boolean;
+    print(...v: any[]): void;
+    printf(format: string, ...v: any[]): void;
+}

--- a/lib/log/defaultLogger.js
+++ b/lib/log/defaultLogger.js
@@ -1,0 +1,38 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+// DefaultLogger is the implementation for a Logger
+class DefaultLogger {
+    constructor() {
+        this.enable = false;
+    }
+    enableLog(enable) {
+        this.enable = enable;
+    }
+    isEnable() {
+        return this.enable;
+    }
+    print(...v) {
+        if (this.enable) {
+            console.log(...v);
+        }
+    }
+    printf(format, ...v) {
+        if (this.enable) {
+            console.log(format, ...v);
+        }
+    }
+}
+exports.DefaultLogger = DefaultLogger;

--- a/lib/log/index.d.ts
+++ b/lib/log/index.d.ts
@@ -1,0 +1,3 @@
+export * from './defaultLogger';
+export * from './logger';
+export * from './logUtil';

--- a/lib/log/index.js
+++ b/lib/log/index.js
@@ -1,0 +1,20 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./defaultLogger"));
+__export(require("./logUtil"));

--- a/lib/log/logUtil.d.ts
+++ b/lib/log/logUtil.d.ts
@@ -1,0 +1,6 @@
+import { Logger } from './logger';
+declare function setLogger(l: Logger): void;
+declare function getLogger(): Logger;
+declare function logPrint(...v: any[]): void;
+declare function logPrintf(format: string, ...v: any[]): void;
+export { setLogger, getLogger, logPrint, logPrintf };

--- a/lib/log/logUtil.js
+++ b/lib/log/logUtil.js
@@ -1,0 +1,37 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const defaultLogger_1 = require("./defaultLogger");
+let logger = new defaultLogger_1.DefaultLogger();
+// setLogger sets the current logger.
+function setLogger(l) {
+    logger = l;
+}
+exports.setLogger = setLogger;
+// getLogger returns the current logger.
+function getLogger() {
+    return logger;
+}
+exports.getLogger = getLogger;
+// logPrint prints the log.
+function logPrint(...v) {
+    logger.print(...v);
+}
+exports.logPrint = logPrint;
+// logPrintf prints the log with the format.
+function logPrintf(format, ...v) {
+    logger.printf(format, ...v);
+}
+exports.logPrintf = logPrintf;

--- a/lib/log/logger.d.ts
+++ b/lib/log/logger.d.ts
@@ -1,0 +1,6 @@
+export interface Logger {
+    enableLog(enable: boolean): void;
+    isEnable(): boolean;
+    print(...v: any[]): void;
+    printf(format: string, ...v: any[]): void;
+}

--- a/lib/log/logger.js
+++ b/lib/log/logger.js
@@ -1,0 +1,15 @@
+"use strict";
+// Copyright 2019 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/managementEnforcer.d.ts
+++ b/lib/managementEnforcer.d.ts
@@ -1,0 +1,286 @@
+import { InternalEnforcer } from './internalEnforcer';
+/**
+ * ManagementEnforcer = InternalEnforcer + Management API.
+ */
+export declare class ManagementEnforcer extends InternalEnforcer {
+    /**
+     * getAllSubjects gets the list of subjects that show up in the current policy.
+     *
+     * @return all the subjects in "p" policy rules. It actually collects the
+     *         0-index elements of "p" policy rules. So make sure your subject
+     *         is the 0-index element, like (sub, obj, act). Duplicates are removed.
+     */
+    getAllSubjects(): string[];
+    /**
+     * getAllNamedSubjects gets the list of subjects that show up in the currentnamed policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the subjects in policy rules of the ptype type. It actually
+     *         collects the 0-index elements of the policy rules. So make sure
+     *         your subject is the 0-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedSubjects(ptype: string): string[];
+    /**
+     * getAllObjects gets the list of objects that show up in the current policy.
+     *
+     * @return all the objects in "p" policy rules. It actually collects the
+     *         1-index elements of "p" policy rules. So make sure your object
+     *         is the 1-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllObjects(): string[];
+    /**
+     * getAllNamedObjects gets the list of objects that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the objects in policy rules of the ptype type. It actually
+     *         collects the 1-index elements of the policy rules. So make sure
+     *         your object is the 1-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedObjects(ptype: string): string[];
+    /**
+     * getAllActions gets the list of actions that show up in the current policy.
+     *
+     * @return all the actions in "p" policy rules. It actually collects
+     *         the 2-index elements of "p" policy rules. So make sure your action
+     *         is the 2-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllActions(): string[];
+    /**
+     * GetAllNamedActions gets the list of actions that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the actions in policy rules of the ptype type. It actually
+     *         collects the 2-index elements of the policy rules. So make sure
+     *         your action is the 2-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedActions(ptype: string): string[];
+    /**
+     * getAllRoles gets the list of roles that show up in the current policy.
+     *
+     * @return all the roles in "g" policy rules. It actually collects
+     *         the 1-index elements of "g" policy rules. So make sure your
+     *         role is the 1-index element, like (sub, role).
+     *         Duplicates are removed.
+     */
+    getAllRoles(): string[];
+    /**
+     * getAllNamedRoles gets the list of roles that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @return all the subjects in policy rules of the ptype type. It actually
+     *         collects the 0-index elements of the policy rules. So make
+     *         sure your subject is the 0-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedRoles(ptype: string): string[];
+    /**
+     * getPolicy gets all the authorization rules in the policy.
+     *
+     * @return all the "p" policy rules.
+     */
+    getPolicy(): string[][];
+    /**
+     * getFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "p" policy rules.
+     */
+    getFilteredPolicy(fieldIndex: number, ...fieldValues: string[]): string[][];
+    /**
+     * getNamedPolicy gets all the authorization rules in the named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return the "p" policy rules of the specified ptype.
+     */
+    getNamedPolicy(ptype: string): string[][];
+    /**
+     * getFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "p" policy rules of the specified ptype.
+     */
+    getFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): string[][];
+    /**
+     * getGroupingPolicy gets all the role inheritance rules in the policy.
+     *
+     * @return all the "g" policy rules.
+     */
+    getGroupingPolicy(): string[][];
+    /**
+     * getFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value "" means not to match this field.
+     * @return the filtered "g" policy rules.
+     */
+    getFilteredGroupingPolicy(fieldIndex: number, ...fieldValues: string[]): string[][];
+    /**
+     * getNamedGroupingPolicy gets all the role inheritance rules in the policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @return the "g" policy rules of the specified ptype.
+     */
+    getNamedGroupingPolicy(ptype: string): string[][];
+    /**
+     * getFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "g" policy rules of the specified ptype.
+     */
+    getFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): string[][];
+    /**
+     * hasPolicy determines whether an authorization rule exists.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return whether the rule exists.
+     */
+    hasPolicy(...params: string[]): boolean;
+    /**
+     * hasNamedPolicy determines whether a named authorization rule exists.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return whether the rule exists.
+     */
+    hasNamedPolicy(ptype: string, ...params: string[]): boolean;
+    /**
+     * addPolicy adds an authorization rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    addPolicy(...params: string[]): Promise<boolean>;
+    /**
+     * addNamedPolicy adds an authorization rule to the current named policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return succeeds or not.
+     */
+    addNamedPolicy(ptype: string, ...params: string[]): Promise<boolean>;
+    /**
+     * removePolicy removes an authorization rule from the current policy.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    removePolicy(...params: string[]): Promise<boolean>;
+    /**
+     * removeFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<boolean>;
+    /**
+     * removeNamedPolicy removes an authorization rule from the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return succeeds or not.
+     */
+    removeNamedPolicy(ptype: string, ...params: string[]): Promise<boolean>;
+    /**
+     * removeFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredNamedPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean>;
+    /**
+     * hasGroupingPolicy determines whether a role inheritance rule exists.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return whether the rule exists.
+     */
+    hasGroupingPolicy(...params: string[]): boolean;
+    /**
+     * hasNamedGroupingPolicy determines whether a named role inheritance rule exists.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return whether the rule exists.
+     */
+    hasNamedGroupingPolicy(ptype: string, ...params: string[]): boolean;
+    /**
+     * addGroupingPolicy adds a role inheritance rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    addGroupingPolicy(...params: string[]): Promise<boolean>;
+    /**
+     * addNamedGroupingPolicy adds a named role inheritance rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return succeeds or not.
+     */
+    addNamedGroupingPolicy(ptype: string, ...params: string[]): Promise<boolean>;
+    /**
+     * removeGroupingPolicy removes a role inheritance rule from the current policy.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    removeGroupingPolicy(...params: string[]): Promise<boolean>;
+    /**
+     * removeFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredGroupingPolicy(fieldIndex: number, ...fieldValues: string[]): Promise<boolean>;
+    /**
+     * removeNamedGroupingPolicy removes a role inheritance rule from the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return succeeds or not.
+     */
+    removeNamedGroupingPolicy(ptype: string, ...params: string[]): Promise<boolean>;
+    /**
+     * removeFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredNamedGroupingPolicy(ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<boolean>;
+    /**
+     * addFunction adds a customized function.
+     * @param name custom function name
+     * @param func function
+     */
+    addFunction(name: string, func: any): void;
+}

--- a/lib/managementEnforcer.js
+++ b/lib/managementEnforcer.js
@@ -1,0 +1,413 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const internalEnforcer_1 = require("./internalEnforcer");
+/**
+ * ManagementEnforcer = InternalEnforcer + Management API.
+ */
+class ManagementEnforcer extends internalEnforcer_1.InternalEnforcer {
+    /**
+     * getAllSubjects gets the list of subjects that show up in the current policy.
+     *
+     * @return all the subjects in "p" policy rules. It actually collects the
+     *         0-index elements of "p" policy rules. So make sure your subject
+     *         is the 0-index element, like (sub, obj, act). Duplicates are removed.
+     */
+    getAllSubjects() {
+        return this.getAllNamedSubjects('p');
+    }
+    /**
+     * getAllNamedSubjects gets the list of subjects that show up in the currentnamed policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the subjects in policy rules of the ptype type. It actually
+     *         collects the 0-index elements of the policy rules. So make sure
+     *         your subject is the 0-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedSubjects(ptype) {
+        return this.model.getValuesForFieldInPolicy('p', ptype, 0);
+    }
+    /**
+     * getAllObjects gets the list of objects that show up in the current policy.
+     *
+     * @return all the objects in "p" policy rules. It actually collects the
+     *         1-index elements of "p" policy rules. So make sure your object
+     *         is the 1-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllObjects() {
+        return this.getAllNamedObjects('p');
+    }
+    /**
+     * getAllNamedObjects gets the list of objects that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the objects in policy rules of the ptype type. It actually
+     *         collects the 1-index elements of the policy rules. So make sure
+     *         your object is the 1-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedObjects(ptype) {
+        return this.model.getValuesForFieldInPolicy('p', ptype, 1);
+    }
+    /**
+     * getAllActions gets the list of actions that show up in the current policy.
+     *
+     * @return all the actions in "p" policy rules. It actually collects
+     *         the 2-index elements of "p" policy rules. So make sure your action
+     *         is the 2-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllActions() {
+        return this.getAllNamedActions('p');
+    }
+    /**
+     * GetAllNamedActions gets the list of actions that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return all the actions in policy rules of the ptype type. It actually
+     *         collects the 2-index elements of the policy rules. So make sure
+     *         your action is the 2-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedActions(ptype) {
+        return this.model.getValuesForFieldInPolicy('p', ptype, 2);
+    }
+    /**
+     * getAllRoles gets the list of roles that show up in the current policy.
+     *
+     * @return all the roles in "g" policy rules. It actually collects
+     *         the 1-index elements of "g" policy rules. So make sure your
+     *         role is the 1-index element, like (sub, role).
+     *         Duplicates are removed.
+     */
+    getAllRoles() {
+        return this.getAllNamedRoles('g');
+    }
+    /**
+     * getAllNamedRoles gets the list of roles that show up in the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @return all the subjects in policy rules of the ptype type. It actually
+     *         collects the 0-index elements of the policy rules. So make
+     *         sure your subject is the 0-index element, like (sub, obj, act).
+     *         Duplicates are removed.
+     */
+    getAllNamedRoles(ptype) {
+        return this.model.getValuesForFieldInPolicy('g', ptype, 1);
+    }
+    /**
+     * getPolicy gets all the authorization rules in the policy.
+     *
+     * @return all the "p" policy rules.
+     */
+    getPolicy() {
+        return this.getNamedPolicy('p');
+    }
+    /**
+     * getFilteredPolicy gets all the authorization rules in the policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "p" policy rules.
+     */
+    getFilteredPolicy(fieldIndex, ...fieldValues) {
+        return this.getFilteredNamedPolicy('p', fieldIndex, ...fieldValues);
+    }
+    /**
+     * getNamedPolicy gets all the authorization rules in the named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @return the "p" policy rules of the specified ptype.
+     */
+    getNamedPolicy(ptype) {
+        return this.model.getPolicy('p', ptype);
+    }
+    /**
+     * getFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "p" policy rules of the specified ptype.
+     */
+    getFilteredNamedPolicy(ptype, fieldIndex, ...fieldValues) {
+        return this.model.getFilteredPolicy('p', ptype, fieldIndex, ...fieldValues);
+    }
+    /**
+     * getGroupingPolicy gets all the role inheritance rules in the policy.
+     *
+     * @return all the "g" policy rules.
+     */
+    getGroupingPolicy() {
+        return this.getNamedGroupingPolicy('g');
+    }
+    /**
+     * getFilteredGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value "" means not to match this field.
+     * @return the filtered "g" policy rules.
+     */
+    getFilteredGroupingPolicy(fieldIndex, ...fieldValues) {
+        return this.getFilteredNamedGroupingPolicy('g', fieldIndex, ...fieldValues);
+    }
+    /**
+     * getNamedGroupingPolicy gets all the role inheritance rules in the policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @return the "g" policy rules of the specified ptype.
+     */
+    getNamedGroupingPolicy(ptype) {
+        return this.model.getPolicy('g', ptype);
+    }
+    /**
+     * getFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return the filtered "g" policy rules of the specified ptype.
+     */
+    getFilteredNamedGroupingPolicy(ptype, fieldIndex, ...fieldValues) {
+        return this.model.getFilteredPolicy('g', ptype, fieldIndex, ...fieldValues);
+    }
+    /**
+     * hasPolicy determines whether an authorization rule exists.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return whether the rule exists.
+     */
+    hasPolicy(...params) {
+        return this.hasNamedPolicy('p', ...params);
+    }
+    /**
+     * hasNamedPolicy determines whether a named authorization rule exists.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return whether the rule exists.
+     */
+    hasNamedPolicy(ptype, ...params) {
+        return this.model.hasPolicy('p', ptype, params);
+    }
+    /**
+     * addPolicy adds an authorization rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    addPolicy(...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.addNamedPolicy('p', ...params);
+        });
+    }
+    /**
+     * addNamedPolicy adds an authorization rule to the current named policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return succeeds or not.
+     */
+    addNamedPolicy(ptype, ...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.addPolicyInternal('p', ptype, params);
+        });
+    }
+    /**
+     * removePolicy removes an authorization rule from the current policy.
+     *
+     * @param params the "p" policy rule, ptype "p" is implicitly used.
+     * @return succeeds or not.
+     */
+    removePolicy(...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeNamedPolicy('p', ...params);
+        });
+    }
+    /**
+     * removeFilteredPolicy removes an authorization rule from the current policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredPolicy(fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredNamedPolicy('p', fieldIndex, ...fieldValues);
+        });
+    }
+    /**
+     * removeNamedPolicy removes an authorization rule from the current named policy.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param params the "p" policy rule.
+     * @return succeeds or not.
+     */
+    removeNamedPolicy(ptype, ...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removePolicyInternal('p', ptype, params);
+        });
+    }
+    /**
+     * removeFilteredNamedPolicy removes an authorization rule from the current named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "p", "p2", "p3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredNamedPolicy(ptype, fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredPolicyInternal('p', ptype, fieldIndex, fieldValues);
+        });
+    }
+    /**
+     * hasGroupingPolicy determines whether a role inheritance rule exists.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return whether the rule exists.
+     */
+    hasGroupingPolicy(...params) {
+        return this.hasNamedGroupingPolicy('g', ...params);
+    }
+    /**
+     * hasNamedGroupingPolicy determines whether a named role inheritance rule exists.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return whether the rule exists.
+     */
+    hasNamedGroupingPolicy(ptype, ...params) {
+        return this.model.hasPolicy('g', ptype, params);
+    }
+    /**
+     * addGroupingPolicy adds a role inheritance rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    addGroupingPolicy(...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.addNamedGroupingPolicy('g', ...params);
+        });
+    }
+    /**
+     * addNamedGroupingPolicy adds a named role inheritance rule to the current policy.
+     * If the rule already exists, the function returns false and the rule will not be added.
+     * Otherwise the function returns true by adding the new rule.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return succeeds or not.
+     */
+    addNamedGroupingPolicy(ptype, ...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleadded = yield this.addPolicyInternal('g', ptype, params);
+            if (this.autoBuildRoleLinks) {
+                this.buildRoleLinks();
+            }
+            return ruleadded;
+        });
+    }
+    /**
+     * removeGroupingPolicy removes a role inheritance rule from the current policy.
+     *
+     * @param params the "g" policy rule, ptype "g" is implicitly used.
+     * @return succeeds or not.
+     */
+    removeGroupingPolicy(...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeNamedGroupingPolicy('g', ...params);
+        });
+    }
+    /**
+     * removeFilteredGroupingPolicy removes a role inheritance rule from the current policy, field filters can be specified.
+     *
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredGroupingPolicy(fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.removeFilteredNamedGroupingPolicy('g', fieldIndex, ...fieldValues);
+        });
+    }
+    /**
+     * removeNamedGroupingPolicy removes a role inheritance rule from the current named policy.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param params the "g" policy rule.
+     * @return succeeds or not.
+     */
+    removeNamedGroupingPolicy(ptype, ...params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleRemoved = yield this.removePolicyInternal('g', ptype, params);
+            if (this.autoBuildRoleLinks) {
+                this.buildRoleLinks();
+            }
+            return ruleRemoved;
+        });
+    }
+    /**
+     * removeFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
+     *
+     * @param ptype the policy type, can be "g", "g2", "g3", ..
+     * @param fieldIndex the policy rule's start index to be matched.
+     * @param fieldValues the field values to be matched, value ""
+     *                    means not to match this field.
+     * @return succeeds or not.
+     */
+    removeFilteredNamedGroupingPolicy(ptype, fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const ruleRemoved = yield this.removeFilteredPolicyInternal('g', ptype, fieldIndex, fieldValues);
+            if (this.autoBuildRoleLinks) {
+                this.buildRoleLinks();
+            }
+            return ruleRemoved;
+        });
+    }
+    /**
+     * addFunction adds a customized function.
+     * @param name custom function name
+     * @param func function
+     */
+    addFunction(name, func) {
+        this.fm.addFunction(name, func);
+    }
+}
+exports.ManagementEnforcer = ManagementEnforcer;

--- a/lib/model/assertion.d.ts
+++ b/lib/model/assertion.d.ts
@@ -1,0 +1,13 @@
+import * as rbac from '../rbac';
+export declare class Assertion {
+    key: string;
+    value: string;
+    tokens: string[];
+    policy: string[][];
+    rm: rbac.RoleManager;
+    /**
+     * constructor is the constructor for Assertion.
+     */
+    constructor();
+    buildRoleLinks(rm: rbac.RoleManager): void;
+}

--- a/lib/model/assertion.js
+++ b/lib/model/assertion.js
@@ -1,0 +1,59 @@
+"use strict";
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const rbac = require("../rbac");
+const _ = require("lodash");
+const log_1 = require("../log");
+// Assertion represents an expression in a section of the model.
+// For example: r = sub, obj, act
+class Assertion {
+    /**
+     * constructor is the constructor for Assertion.
+     */
+    constructor() {
+        this.key = '';
+        this.value = '';
+        this.tokens = [];
+        this.policy = [];
+        this.rm = new rbac.DefaultRoleManager(0);
+    }
+    buildRoleLinks(rm) {
+        this.rm = rm;
+        const count = _.words(this.value, /_/g).length;
+        for (const rule of this.policy) {
+            if (count < 2) {
+                throw new Error('the number of "_" in role definition should be at least 2');
+            }
+            if (rule.length < count) {
+                throw new Error('grouping policy elements do not meet role definition');
+            }
+            if (count === 2) {
+                // error intentionally ignored
+                this.rm.addLink(rule[0], rule[1]);
+            }
+            else if (count === 3) {
+                // error intentionally ignored
+                this.rm.addLink(rule[0], rule[1], rule[2]);
+            }
+            else if (count === 4) {
+                // error intentionally ignored
+                this.rm.addLink(rule[0], rule[1], rule[2], rule[3]);
+            }
+        }
+        log_1.logPrint(`Role links for: ${this.key}`);
+        this.rm.printRoles();
+    }
+}
+exports.Assertion = Assertion;

--- a/lib/model/functionMap.d.ts
+++ b/lib/model/functionMap.d.ts
@@ -1,0 +1,10 @@
+export declare class FunctionMap {
+    private functions;
+    /**
+     * constructor is the constructor for FunctionMap.
+     */
+    constructor();
+    static loadFunctionMap(): FunctionMap;
+    addFunction(name: string, func: any): void;
+    getFunctions(): any;
+}

--- a/lib/model/functionMap.js
+++ b/lib/model/functionMap.js
@@ -1,0 +1,45 @@
+"use strict";
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const util = require("../util");
+// FunctionMap represents the collection of Function.
+class FunctionMap {
+    /**
+     * constructor is the constructor for FunctionMap.
+     */
+    constructor() {
+        this.functions = new Map();
+    }
+    // loadFunctionMap loads an initial function map.
+    static loadFunctionMap() {
+        const fm = new FunctionMap();
+        fm.addFunction('keyMatch', util.keyMatchFunc);
+        fm.addFunction('keyMatch2', util.keyMatch2Func);
+        fm.addFunction('regexMatch', util.regexMatchFunc);
+        fm.addFunction('ipMatch', util.ipMatchFunc);
+        return fm;
+    }
+    // addFunction adds an expression function.
+    addFunction(name, func) {
+        if (!this.functions.get(name)) {
+            this.functions.set(name, func);
+        }
+    }
+    // getFunctions return all functions.
+    getFunctions() {
+        return this.functions;
+    }
+}
+exports.FunctionMap = FunctionMap;

--- a/lib/model/index.d.ts
+++ b/lib/model/index.d.ts
@@ -1,0 +1,3 @@
+export * from './assertion';
+export * from './functionMap';
+export * from './model';

--- a/lib/model/index.js
+++ b/lib/model/index.js
@@ -1,0 +1,21 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./assertion"));
+__export(require("./functionMap"));
+__export(require("./model"));

--- a/lib/model/model.d.ts
+++ b/lib/model/model.d.ts
@@ -1,0 +1,26 @@
+import * as rbac from '../rbac';
+import { Assertion } from './assertion';
+export declare class Model {
+    model: Map<string, Map<string, Assertion>>;
+    /**
+     * constructor is the constructor for Model.
+     */
+    constructor();
+    private loadAssertion;
+    private getKeySuffix;
+    private loadSection;
+    addDef(sec: string, key: string, value: string): boolean;
+    loadModel(path: string): void;
+    loadModelFromText(text: string): void;
+    printModel(): void;
+    buildRoleLinks(rm: rbac.RoleManager): void;
+    clearPolicy(): void;
+    getPolicy(sec: string, key: string): string[][];
+    hasPolicy(sec: string, key: string, rule: string[]): boolean;
+    addPolicy(sec: string, key: string, rule: string[]): boolean;
+    removePolicy(sec: string, key: string, rule: string[]): boolean;
+    getFilteredPolicy(sec: string, key: string, fieldIndex: number, ...fieldValues: string[]): string[][];
+    removeFilteredPolicy(sec: string, key: string, fieldIndex: number, ...fieldValues: string[]): boolean;
+    getValuesForFieldInPolicy(sec: string, key: string, fieldIndex: number): string[];
+    printPolicy(): void;
+}

--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -1,0 +1,248 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const _ = require("lodash");
+const util = require("../util");
+const config_1 = require("../config");
+const assertion_1 = require("./assertion");
+const log_1 = require("../log");
+const sectionNameMap = {
+    r: 'request_definition',
+    p: 'policy_definition',
+    g: 'role_definition',
+    e: 'policy_effect',
+    m: 'matchers'
+};
+class Model {
+    /**
+     * constructor is the constructor for Model.
+     */
+    constructor() {
+        this.model = new Map();
+    }
+    loadAssertion(cfg, sec, key) {
+        // console.log('loadAssertion: ', sec, key);
+        const secName = sectionNameMap[sec];
+        const value = cfg.getString(`${secName}::${key}`);
+        return this.addDef(sec, key, value);
+    }
+    getKeySuffix(i) {
+        if (i === 1) {
+            return '';
+        }
+        return _.toString(i);
+    }
+    loadSection(cfg, sec) {
+        // console.log('loadSection: ', sec);
+        let i = 1;
+        for (;;) {
+            if (!this.loadAssertion(cfg, sec, sec + this.getKeySuffix(i))) {
+                break;
+            }
+            else {
+                i++;
+            }
+        }
+    }
+    // addDef adds an assertion to the model.
+    addDef(sec, key, value) {
+        // console.log('addDef: ', sec, key. value);
+        if (value === '') {
+            return false;
+        }
+        const ast = new assertion_1.Assertion();
+        ast.key = key;
+        ast.value = value;
+        if (sec === 'r' || sec === 'p') {
+            const tokens = value.split(', ');
+            for (let i = 0; i < tokens.length; i++) {
+                tokens[i] = key + '_' + tokens[i];
+            }
+            ast.tokens = tokens;
+        }
+        else {
+            ast.value = util.removeComments(util.escapeAssertion(value));
+        }
+        const nodeMap = this.model.get(sec);
+        if (nodeMap) {
+            nodeMap.set(key, ast);
+        }
+        else {
+            const assertionMap = new Map();
+            assertionMap.set(key, ast);
+            this.model.set(sec, assertionMap);
+        }
+        return true;
+    }
+    // loadModel loads the model from model CONF file.
+    loadModel(path) {
+        // console.log('loadModel: ', path);
+        const cfg = config_1.Config.newConfig(path);
+        this.loadSection(cfg, 'r');
+        this.loadSection(cfg, 'p');
+        this.loadSection(cfg, 'e');
+        this.loadSection(cfg, 'm');
+        this.loadSection(cfg, 'g');
+    }
+    // loadModelFromText loads the model from the text.
+    loadModelFromText(text) {
+        const cfg = config_1.Config.newConfigFromText(text);
+        this.loadSection(cfg, 'r');
+        this.loadSection(cfg, 'p');
+        this.loadSection(cfg, 'e');
+        this.loadSection(cfg, 'm');
+        this.loadSection(cfg, 'g');
+    }
+    // printModel prints the model to the log.
+    printModel() {
+        log_1.logPrint('Model:');
+        this.model.forEach((value, key) => {
+            value.forEach((ast, astKey) => {
+                log_1.logPrint(`${key}.${astKey}: ${ast.value}`);
+            });
+        });
+    }
+    // buildRoleLinks initializes the roles in RBAC.
+    buildRoleLinks(rm) {
+        const astMap = this.model.get('g');
+        if (!astMap) {
+            return;
+        }
+        astMap.forEach(value => {
+            value.buildRoleLinks(rm);
+        });
+    }
+    // clearPolicy clears all current policy.
+    clearPolicy() {
+        this.model.forEach((value, key) => {
+            if (key === 'p' || key === 'g') {
+                value.forEach(ast => {
+                    ast.policy = [];
+                });
+            }
+        });
+    }
+    // getPolicy gets all rules in a policy.
+    getPolicy(sec, key) {
+        const policy = [];
+        const ast = (this.model.get(sec) || new Map()).get(key);
+        if (ast) {
+            policy.push(...ast.policy);
+        }
+        return policy;
+    }
+    // hasPolicy determines whether a model has the specified policy rule.
+    hasPolicy(sec, key, rule) {
+        const ast = (this.model.get(sec) || new Map()).get(key);
+        if (!ast) {
+            return false;
+        }
+        return ast.policy.some((n) => util.arrayEquals(n, rule));
+    }
+    // addPolicy adds a policy rule to the model.
+    addPolicy(sec, key, rule) {
+        if (!this.hasPolicy(sec, key, rule)) {
+            const ast = (this.model.get(sec) || new Map()).get(key);
+            if (!ast) {
+                return false;
+            }
+            ast.policy.push(rule);
+            return true;
+        }
+        return false;
+    }
+    // removePolicy removes a policy rule from the model.
+    removePolicy(sec, key, rule) {
+        if (this.hasPolicy(sec, key, rule)) {
+            const ast = (this.model.get(sec) || new Map()).get(key);
+            if (!ast) {
+                return true;
+            }
+            ast.policy = _.filter(ast.policy, r => !util.arrayEquals(rule, r));
+            return true;
+        }
+        return false;
+    }
+    // getFilteredPolicy gets rules based on field filters from a policy.
+    getFilteredPolicy(sec, key, fieldIndex, ...fieldValues) {
+        const res = [];
+        const ast = (this.model.get(sec) || new Map()).get(key);
+        if (!ast) {
+            return res;
+        }
+        for (const rule of ast.policy) {
+            let matched = true;
+            for (let i = 0; i < fieldValues.length; i++) {
+                const fieldValue = fieldValues[i];
+                if (fieldValue !== '' && rule[fieldIndex + i] !== fieldValue) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                res.push(rule);
+            }
+        }
+        return res;
+    }
+    // removeFilteredPolicy removes policy rules based on field filters from the model.
+    removeFilteredPolicy(sec, key, fieldIndex, ...fieldValues) {
+        const res = [];
+        let bool = false;
+        const ast = (this.model.get(sec) || new Map()).get(key);
+        if (!ast) {
+            return bool;
+        }
+        for (const rule of ast.policy) {
+            let matched = true;
+            for (let i = 0; i < fieldValues.length; i++) {
+                const fieldValue = fieldValues[i];
+                if (fieldValue !== '' && rule[fieldIndex + i] !== fieldValue) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                bool = true;
+            }
+            else {
+                res.push(rule);
+            }
+        }
+        ast.policy = res;
+        return bool;
+    }
+    // getValuesForFieldInPolicy gets all values for a field for all rules in a policy, duplicated values are removed.
+    getValuesForFieldInPolicy(sec, key, fieldIndex) {
+        const values = [];
+        const ast = (this.model.get(sec) || new Map()).get(key);
+        if (!ast) {
+            return values;
+        }
+        return util.arrayRemoveDuplicates(ast.policy.map((n) => n[fieldIndex]));
+    }
+    // printPolicy prints the policy to log.
+    printPolicy() {
+        log_1.logPrint('Policy:');
+        this.model.forEach((map, key) => {
+            if (key === 'p' || key === 'g') {
+                map.forEach(ast => {
+                    log_1.logPrint(`key, : ${ast.value}, : , ${ast.policy}`);
+                });
+            }
+        });
+    }
+}
+exports.Model = Model;

--- a/lib/persist/adapter.d.ts
+++ b/lib/persist/adapter.d.ts
@@ -1,0 +1,8 @@
+import { Model } from '../model';
+export interface Adapter {
+    loadPolicy(model: Model): Promise<void>;
+    savePolicy(model: Model): Promise<boolean>;
+    addPolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    removePolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    removeFilteredPolicy(sec: string, ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<void>;
+}

--- a/lib/persist/adapter.js
+++ b/lib/persist/adapter.js
@@ -1,0 +1,15 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/persist/defaultFilteredAdapter.d.ts
+++ b/lib/persist/defaultFilteredAdapter.d.ts
@@ -1,0 +1,18 @@
+import { FilteredAdapter } from './filteredAdapter';
+import { Model } from '../model';
+import { FileAdapter } from './fileAdapter';
+export declare class Filter {
+    g: string[];
+    p: string[];
+}
+export declare class DefaultFilteredAdapter extends FileAdapter implements FilteredAdapter {
+    private filtered;
+    constructor(filePath: string);
+    loadPolicy(model: Model): Promise<void>;
+    loadFilteredPolicy(model: Model, filter: Filter): Promise<void>;
+    private loadFilteredPolicyFile;
+    isFiltered(): boolean;
+    savePolicy(model: Model): Promise<boolean>;
+    private static filterLine;
+    private static filterWords;
+}

--- a/lib/persist/defaultFilteredAdapter.js
+++ b/lib/persist/defaultFilteredAdapter.js
@@ -1,0 +1,111 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const fileAdapter_1 = require("./fileAdapter");
+const helper_1 = require("./helper");
+const util_1 = require("../util");
+class Filter {
+    constructor() {
+        this.g = [];
+        this.p = [];
+    }
+}
+exports.Filter = Filter;
+class DefaultFilteredAdapter extends fileAdapter_1.FileAdapter {
+    constructor(filePath) {
+        super(filePath);
+        this.filtered = false;
+    }
+    // loadPolicy loads all policy rules from the storage.
+    loadPolicy(model) {
+        const _super = Object.create(null, {
+            loadPolicy: { get: () => super.loadPolicy }
+        });
+        return __awaiter(this, void 0, void 0, function* () {
+            this.filtered = false;
+            yield _super.loadPolicy.call(this, model);
+        });
+    }
+    loadFilteredPolicy(model, filter) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!filter) {
+                yield this.loadPolicy(model);
+                return;
+            }
+            if (!this.filePath) {
+                throw new Error('invalid file path, file path cannot be empty');
+            }
+            yield this.loadFilteredPolicyFile(model, filter, helper_1.Helper.loadPolicyLine);
+            this.filtered = true;
+        });
+    }
+    loadFilteredPolicyFile(model, filter, handler) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const bodyBuf = yield util_1.readFile(this.filePath);
+            const lines = bodyBuf.toString().split('\n');
+            lines.forEach((n, index) => {
+                const line = n.trim();
+                if (!line || DefaultFilteredAdapter.filterLine(line, filter)) {
+                    return;
+                }
+                handler(line, model);
+            });
+        });
+    }
+    isFiltered() {
+        return this.filtered;
+    }
+    savePolicy(model) {
+        const _super = Object.create(null, {
+            savePolicy: { get: () => super.savePolicy }
+        });
+        return __awaiter(this, void 0, void 0, function* () {
+            if (this.filtered) {
+                throw new Error('cannot save a filtered policy');
+            }
+            yield _super.savePolicy.call(this, model);
+            return true;
+        });
+    }
+    static filterLine(line, filter) {
+        if (!filter) {
+            return false;
+        }
+        const p = line.split(',');
+        if (p.length === 0) {
+            return true;
+        }
+        let filterSlice = [];
+        switch (p[0].trim()) {
+            case 'p':
+                filterSlice = filter.p;
+                break;
+            case 'g':
+                filterSlice = filter.g;
+                break;
+        }
+        return DefaultFilteredAdapter.filterWords(p, filterSlice);
+    }
+    static filterWords(line, filter) {
+        if (line.length < filter.length + 1) {
+            return true;
+        }
+        let skipLine = false;
+        for (let i = 0; i < filter.length; i++) {
+            if (filter[i] && filter[i].trim() !== filter[i + 1].trim()) {
+                skipLine = true;
+                break;
+            }
+        }
+        return skipLine;
+    }
+}
+exports.DefaultFilteredAdapter = DefaultFilteredAdapter;

--- a/lib/persist/fileAdapter.d.ts
+++ b/lib/persist/fileAdapter.d.ts
@@ -1,0 +1,33 @@
+import { Adapter } from './adapter';
+import { Model } from '../model';
+/**
+ * FileAdapter is the file adapter for Casbin.
+ * It can load policy from file or save policy to file.
+ */
+export declare class FileAdapter implements Adapter {
+    readonly filePath: string;
+    /**
+     * FileAdapter is the constructor for FileAdapter.
+     * @param {string} filePath filePath the path of the policy file.
+     */
+    constructor(filePath: string);
+    loadPolicy(model: Model): Promise<void>;
+    private loadPolicyFile;
+    /**
+     * savePolicy saves all policy rules to the storage.
+     */
+    savePolicy(model: Model): Promise<boolean>;
+    private savePolicyFile;
+    /**
+     * addPolicy adds a policy rule to the storage.
+     */
+    addPolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    /**
+     * removePolicy removes a policy rule from the storage.
+     */
+    removePolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    /**
+     * removeFilteredPolicy removes policy rules that match the filter from the storage.
+     */
+    removeFilteredPolicy(sec: string, ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<void>;
+}

--- a/lib/persist/fileAdapter.js
+++ b/lib/persist/fileAdapter.js
@@ -1,0 +1,114 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const helper_1 = require("./helper");
+const util_1 = require("../util");
+/**
+ * FileAdapter is the file adapter for Casbin.
+ * It can load policy from file or save policy to file.
+ */
+class FileAdapter {
+    /**
+     * FileAdapter is the constructor for FileAdapter.
+     * @param {string} filePath filePath the path of the policy file.
+     */
+    constructor(filePath) {
+        this.filePath = filePath;
+    }
+    loadPolicy(model) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!this.filePath) {
+                // throw new Error('invalid file path, file path cannot be empty');
+                return;
+            }
+            yield this.loadPolicyFile(model, helper_1.Helper.loadPolicyLine);
+        });
+    }
+    loadPolicyFile(model, handler) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const bodyBuf = yield util_1.readFile(this.filePath);
+            const lines = bodyBuf.toString().split('\n');
+            lines.forEach((n, index) => {
+                const line = n.trim();
+                if (!line) {
+                    return;
+                }
+                handler(n, model);
+            });
+        });
+    }
+    /**
+     * savePolicy saves all policy rules to the storage.
+     */
+    savePolicy(model) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!this.filePath) {
+                // throw new Error('invalid file path, file path cannot be empty');
+                return false;
+            }
+            let result = '';
+            const pList = model.model.get('p');
+            if (!pList) {
+                return false;
+            }
+            pList.forEach(n => {
+                n.policy.forEach(m => {
+                    result += n.key + ', ';
+                    result += util_1.arrayToString(m);
+                    result += '\n';
+                });
+            });
+            const gList = model.model.get('g');
+            if (!gList) {
+                return false;
+            }
+            gList.forEach(n => {
+                n.policy.forEach(m => {
+                    result += n.key + ', ';
+                    result += util_1.arrayToString(m);
+                    result += '\n';
+                });
+            });
+            yield this.savePolicyFile(result.trim());
+            return true;
+        });
+    }
+    savePolicyFile(text) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield util_1.writeFile(this.filePath, text);
+        });
+    }
+    /**
+     * addPolicy adds a policy rule to the storage.
+     */
+    addPolicy(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+        });
+    }
+    /**
+     * removePolicy removes a policy rule from the storage.
+     */
+    removePolicy(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+        });
+    }
+    /**
+     * removeFilteredPolicy removes policy rules that match the filter from the storage.
+     */
+    removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            throw new Error('not implemented');
+        });
+    }
+}
+exports.FileAdapter = FileAdapter;

--- a/lib/persist/filteredAdapter.d.ts
+++ b/lib/persist/filteredAdapter.d.ts
@@ -1,0 +1,6 @@
+import { Model } from '../model';
+import { Adapter } from './adapter';
+export interface FilteredAdapter extends Adapter {
+    loadFilteredPolicy(model: Model, filter: any): Promise<void>;
+    isFiltered(): boolean;
+}

--- a/lib/persist/filteredAdapter.js
+++ b/lib/persist/filteredAdapter.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/persist/helper.d.ts
+++ b/lib/persist/helper.d.ts
@@ -1,0 +1,4 @@
+import { Model } from '../model';
+export declare class Helper {
+    static loadPolicyLine(line: string, model: Model): void;
+}

--- a/lib/persist/helper.js
+++ b/lib/persist/helper.js
@@ -1,0 +1,22 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class Helper {
+    static loadPolicyLine(line, model) {
+        if (line === '' || line.charAt(0) === '#') {
+            return;
+        }
+        const tokens = line.split(', ').map(n => n.trim());
+        const key = tokens[0];
+        const sec = key.substring(0, 1);
+        const item = model.model.get(sec);
+        if (!item) {
+            return;
+        }
+        const policy = item.get(key);
+        if (!policy) {
+            return;
+        }
+        policy.policy.push(tokens.slice(1));
+    }
+}
+exports.Helper = Helper;

--- a/lib/persist/index.d.ts
+++ b/lib/persist/index.d.ts
@@ -1,0 +1,6 @@
+export * from './adapter';
+export * from './fileAdapter';
+export * from './helper';
+export * from './watcher';
+export * from './filteredAdapter';
+export * from './defaultFilteredAdapter';

--- a/lib/persist/index.js
+++ b/lib/persist/index.js
@@ -1,0 +1,8 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./fileAdapter"));
+__export(require("./helper"));
+__export(require("./defaultFilteredAdapter"));

--- a/lib/persist/watcher.d.ts
+++ b/lib/persist/watcher.d.ts
@@ -1,0 +1,4 @@
+export interface Watcher {
+    setUpdateCallback(cb: () => void): void;
+    update(): boolean;
+}

--- a/lib/persist/watcher.js
+++ b/lib/persist/watcher.js
@@ -1,0 +1,15 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/rbac/defaultRoleManager.d.ts
+++ b/lib/rbac/defaultRoleManager.d.ts
@@ -1,0 +1,49 @@
+import { RoleManager } from './roleManager';
+export declare class DefaultRoleManager implements RoleManager {
+    private allRoles;
+    private maxHierarchyLevel;
+    /**
+     * DefaultRoleManager is the constructor for creating an instance of the
+     * default RoleManager implementation.
+     *
+     * @param maxHierarchyLevel the maximized allowed RBAC hierarchy level.
+     */
+    constructor(maxHierarchyLevel: number);
+    /**
+     * addLink adds the inheritance link between role: name1 and role: name2.
+     * aka role: name1 inherits role: name2.
+     * domain is a prefix to the roles.
+     */
+    addLink(name1: string, name2: string, ...domain: string[]): void;
+    /**
+     * clear clears all stored data and resets the role manager to the initial state.
+     */
+    clear(): void;
+    /**
+     * deleteLink deletes the inheritance link between role: name1 and role: name2.
+     * aka role: name1 does not inherit role: name2 any more.
+     * domain is a prefix to the roles.
+     */
+    deleteLink(name1: string, name2: string, ...domain: string[]): void;
+    /**
+     * getRoles gets the roles that a subject inherits.
+     * domain is a prefix to the roles.
+     */
+    getRoles(name: string, ...domain: string[]): string[];
+    /**
+     * getUsers gets the users that inherits a subject.
+     * domain is an unreferenced parameter here, may be used in other implementations.
+     */
+    getUsers(name: string, ...domain: string[]): string[];
+    /**
+     * hasLink determines whether role: name1 inherits role: name2.
+     * domain is a prefix to the roles.
+     */
+    hasLink(name1: string, name2: string, ...domain: string[]): boolean;
+    /**
+     * printRoles prints all the roles to log.
+     */
+    printRoles(): void;
+    private createRole;
+    private hasRole;
+}

--- a/lib/rbac/defaultRoleManager.js
+++ b/lib/rbac/defaultRoleManager.js
@@ -1,0 +1,199 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const log_1 = require("../log");
+// RoleManager provides a default implementation for the RoleManager interface
+class DefaultRoleManager {
+    /**
+     * DefaultRoleManager is the constructor for creating an instance of the
+     * default RoleManager implementation.
+     *
+     * @param maxHierarchyLevel the maximized allowed RBAC hierarchy level.
+     */
+    constructor(maxHierarchyLevel) {
+        this.allRoles = new Map();
+        this.maxHierarchyLevel = maxHierarchyLevel;
+    }
+    /**
+     * addLink adds the inheritance link between role: name1 and role: name2.
+     * aka role: name1 inherits role: name2.
+     * domain is a prefix to the roles.
+     */
+    addLink(name1, name2, ...domain) {
+        if (domain.length === 1) {
+            name1 = domain[0] + '::' + name1;
+            name2 = domain[0] + '::' + name2;
+        }
+        else if (domain.length > 1) {
+            throw new Error('error: domain should be 1 parameter');
+        }
+        const role1 = this.createRole(name1);
+        const role2 = this.createRole(name2);
+        role1.addRole(role2);
+    }
+    /**
+     * clear clears all stored data and resets the role manager to the initial state.
+     */
+    clear() {
+        this.allRoles = new Map();
+    }
+    /**
+     * deleteLink deletes the inheritance link between role: name1 and role: name2.
+     * aka role: name1 does not inherit role: name2 any more.
+     * domain is a prefix to the roles.
+     */
+    deleteLink(name1, name2, ...domain) {
+        if (domain.length === 1) {
+            name1 = domain[0] + '::' + name1;
+            name2 = domain[0] + '::' + name2;
+        }
+        else if (domain.length > 1) {
+            throw new Error('error: domain should be 1 parameter');
+        }
+        if (!this.hasRole(name1) || !this.hasRole(name2)) {
+            return;
+        }
+        const role1 = this.createRole(name1);
+        const role2 = this.createRole(name2);
+        role1.deleteRole(role2);
+    }
+    /**
+     * getRoles gets the roles that a subject inherits.
+     * domain is a prefix to the roles.
+     */
+    getRoles(name, ...domain) {
+        if (domain.length === 1) {
+            name = domain[0] + '::' + name;
+        }
+        else if (domain.length > 1) {
+            throw new Error('error: domain should be 1 parameter');
+        }
+        if (!this.hasRole(name)) {
+            return [];
+        }
+        let roles = this.createRole(name).getRoles();
+        if (domain.length === 1) {
+            roles = roles.map(n => n.substring(domain[0].length + 2, n.length));
+        }
+        return roles;
+    }
+    /**
+     * getUsers gets the users that inherits a subject.
+     * domain is an unreferenced parameter here, may be used in other implementations.
+     */
+    getUsers(name, ...domain) {
+        if (domain.length === 1) {
+            name = domain[0] + '::' + name;
+        }
+        else if (domain.length > 1) {
+            throw new Error('error: domain should be 1 parameter');
+        }
+        if (!this.hasRole(name)) {
+            return [];
+        }
+        let users = [...this.allRoles.values()]
+            .filter(n => n.hasDirectRole(name))
+            .map(n => n.name);
+        if (domain.length === 1) {
+            users = users.map(n => n.substring(domain[0].length + 2, n.length));
+        }
+        return users;
+    }
+    /**
+     * hasLink determines whether role: name1 inherits role: name2.
+     * domain is a prefix to the roles.
+     */
+    hasLink(name1, name2, ...domain) {
+        if (domain.length === 1) {
+            name1 = domain[0] + '::' + name1;
+            name2 = domain[0] + '::' + name2;
+        }
+        else if (domain.length > 1) {
+            throw new Error('error: domain should be 1 parameter');
+        }
+        if (name1 === name2) {
+            return true;
+        }
+        if (!this.hasRole(name1) || !this.hasRole(name2)) {
+            return false;
+        }
+        const role1 = this.createRole(name1);
+        return role1.hasRole(name2, this.maxHierarchyLevel);
+    }
+    /**
+     * printRoles prints all the roles to log.
+     */
+    printRoles() {
+        [...this.allRoles.values()].map(n => {
+            log_1.logPrint(n.toString());
+        });
+    }
+    createRole(name) {
+        const role = this.allRoles.get(name);
+        if (role) {
+            return role;
+        }
+        else {
+            const newRole = new Role(name);
+            this.allRoles.set(name, newRole);
+            return newRole;
+        }
+    }
+    hasRole(name) {
+        return this.allRoles.has(name);
+    }
+}
+exports.DefaultRoleManager = DefaultRoleManager;
+/**
+ * Role represents the data structure for a role in RBAC.
+ */
+class Role {
+    constructor(name) {
+        this.name = name;
+        this.roles = [];
+    }
+    addRole(role) {
+        if (this.roles.some(n => n.name === role.name)) {
+            return;
+        }
+        this.roles.push(role);
+    }
+    deleteRole(role) {
+        this.roles = this.roles.filter(n => n.name !== role.name);
+    }
+    hasRole(name, hierarchyLevel) {
+        if (this.name === name) {
+            return true;
+        }
+        if (hierarchyLevel <= 0) {
+            return false;
+        }
+        for (const role of this.roles) {
+            if (role.hasRole(name, hierarchyLevel - 1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    hasDirectRole(name) {
+        return this.roles.some(n => n.name === name);
+    }
+    toString() {
+        return this.name + this.roles.join(', ');
+    }
+    getRoles() {
+        return this.roles.map(n => n.name);
+    }
+}

--- a/lib/rbac/index.d.ts
+++ b/lib/rbac/index.d.ts
@@ -1,0 +1,2 @@
+export * from './defaultRoleManager';
+export * from './roleManager';

--- a/lib/rbac/index.js
+++ b/lib/rbac/index.js
@@ -1,0 +1,19 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./defaultRoleManager"));

--- a/lib/rbac/roleManager.d.ts
+++ b/lib/rbac/roleManager.d.ts
@@ -1,0 +1,9 @@
+export interface RoleManager {
+    clear(): void;
+    addLink(name1: string, name2: string, ...domain: string[]): void;
+    deleteLink(name1: string, name2: string, ...domain: string[]): void;
+    hasLink(name1: string, name2: string, ...domain: string[]): boolean;
+    getRoles(name: string, ...domain: string[]): string[];
+    getUsers(name: string, ...domain: string[]): string[];
+    printRoles(): void;
+}

--- a/lib/rbac/roleManager.js
+++ b/lib/rbac/roleManager.js
@@ -1,0 +1,15 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/util/builtinOperators.d.ts
+++ b/lib/util/builtinOperators.d.ts
@@ -1,0 +1,8 @@
+import * as rbac from '../rbac';
+declare function keyMatchFunc(...args: any[]): boolean;
+declare function keyMatch2Func(...args: any[]): boolean;
+declare function keyMatch3Func(...args: any[]): boolean;
+declare function regexMatchFunc(...args: any[]): boolean;
+declare function ipMatchFunc(...args: any[]): boolean;
+declare function generateGFunction(rm: rbac.RoleManager): any;
+export { keyMatchFunc, keyMatch2Func, keyMatch3Func, regexMatchFunc, ipMatchFunc, generateGFunction };

--- a/lib/util/builtinOperators.js
+++ b/lib/util/builtinOperators.js
@@ -1,0 +1,135 @@
+"use strict";
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const ip = require("ip");
+const _ = require("lodash");
+// keyMatch determines whether key1 matches the pattern of key2 (similar to RESTful path),
+// key2 can contain a *.
+// For example, '/foo/bar' matches '/foo/*'
+function keyMatch(key1, key2) {
+    const pos = key2.indexOf('*');
+    if (pos === -1) {
+        return key1 === key2;
+    }
+    if (key1.length > pos) {
+        return key1.slice(0, pos) === key2.slice(0, pos);
+    }
+    return key1 === key2.slice(0, pos);
+}
+// keyMatchFunc is the wrapper for keyMatch.
+function keyMatchFunc(...args) {
+    const name1 = _.toString(args[0]);
+    const name2 = _.toString(args[1]);
+    return keyMatch(name1, name2);
+}
+exports.keyMatchFunc = keyMatchFunc;
+// keyMatch2 determines whether key1 matches the pattern of key2 (similar to RESTful path),
+// key2 can contain a *.
+// For example, '/foo/bar' matches '/foo/*', '/resource1' matches '/:resource'
+function keyMatch2(key1, key2) {
+    key2 = key2.replace(/\/\*/g, '/.*');
+    const regexp = new RegExp(/(.*):[^/]+(.*)/g);
+    for (;;) {
+        if (!_.includes(key2, '/:')) {
+            break;
+        }
+        key2 = key2.replace(regexp, '$1[^/]+$2');
+    }
+    return regexMatch(key1, '^' + key2 + '$');
+}
+// keyMatch2Func is the wrapper for keyMatch2.
+function keyMatch2Func(...args) {
+    const name1 = _.toString(args[0]);
+    const name2 = _.toString(args[1]);
+    return keyMatch2(name1, name2);
+}
+exports.keyMatch2Func = keyMatch2Func;
+// keyMatch3 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *.
+// For example, '/foo/bar' matches '/foo/*', '/resource1' matches '/{resource}'
+function keyMatch3(key1, key2) {
+    key2 = key2.replace(/\/\*/g, '/.*');
+    const regexp = new RegExp(/(.*){[^/]+}(.*)/g);
+    for (;;) {
+        if (!_.includes(key2, '/{')) {
+            break;
+        }
+        key2 = key2.replace(regexp, '$1[^/]+$2');
+    }
+    return regexMatch(key1, key2);
+}
+// keyMatch3Func is the wrapper for keyMatch3.
+function keyMatch3Func(...args) {
+    const name1 = _.toString(args[0]);
+    const name2 = _.toString(args[1]);
+    return keyMatch3(name1, name2);
+}
+exports.keyMatch3Func = keyMatch3Func;
+// regexMatch determines whether key1 matches the pattern of key2 in regular expression.
+function regexMatch(key1, key2) {
+    return new RegExp(key2).test(key1);
+}
+// regexMatchFunc is the wrapper for regexMatch.
+function regexMatchFunc(...args) {
+    const name1 = _.toString(args[0]);
+    const name2 = _.toString(args[1]);
+    return regexMatch(name1, name2);
+}
+exports.regexMatchFunc = regexMatchFunc;
+// ipMatch determines whether IP address ip1 matches the pattern of IP address ip2,
+// ip2 can be an IP address or a CIDR pattern.
+// For example, '192.168.2.123' matches '192.168.2.0/24'
+function ipMatch(ip1, ip2) {
+    // check ip1
+    if (!(ip.isV4Format(ip1) || ip.isV6Format(ip1))) {
+        throw new Error('invalid argument: ip1 in ipMatch() function is not an IP address.');
+    }
+    // check ip2
+    const cidrParts = ip2.split('/');
+    if (cidrParts.length === 2) {
+        return ip.cidrSubnet(ip2).contains(ip1);
+    }
+    else {
+        if (!(ip.isV4Format(ip2) || ip.isV6Format(ip2))) {
+            console.log(ip2);
+            throw new Error('invalid argument: ip2 in ipMatch() function is not an IP address.');
+        }
+        return ip.isEqual(ip1, ip2);
+    }
+}
+// ipMatchFunc is the wrapper for ipMatch.
+function ipMatchFunc(...args) {
+    const ip1 = _.toString(args[0]);
+    const ip2 = _.toString(args[1]);
+    return ipMatch(ip1, ip2);
+}
+exports.ipMatchFunc = ipMatchFunc;
+// generateGFunction is the factory method of the g(_, _) function.
+function generateGFunction(rm) {
+    return function func(...args) {
+        const name1 = _.toString(args[0]);
+        const name2 = _.toString(args[1]);
+        if (!rm) {
+            return name1 === name2;
+        }
+        else if (args.length === 2) {
+            return rm.hasLink(name1, name2);
+        }
+        else {
+            const domain = _.toString(args[2]);
+            return rm.hasLink(name1, name2, domain);
+        }
+    };
+}
+exports.generateGFunction = generateGFunction;

--- a/lib/util/index.d.ts
+++ b/lib/util/index.d.ts
@@ -1,0 +1,2 @@
+export * from './builtinOperators';
+export * from './util';

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1,0 +1,20 @@
+"use strict";
+// Copyright 2018 The Casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./builtinOperators"));
+__export(require("./util"));

--- a/lib/util/util.d.ts
+++ b/lib/util/util.d.ts
@@ -1,0 +1,11 @@
+declare function escapeAssertion(s: string): string;
+declare function removeComments(s: string): string;
+declare function arrayEquals(a: string[], b: string[]): boolean;
+declare function array2DEquals(a: string[][], b: string[][]): boolean;
+declare function arrayRemoveDuplicates(s: string[]): string[];
+declare function arrayToString(a: string[]): string;
+declare function paramsToString(...v: string[]): string;
+declare function setEquals(a: string[], b: string[]): boolean;
+declare function readFile(path: string, encoding?: string): any;
+declare function writeFile(path: string, file: string, encoding?: string): any;
+export { escapeAssertion, removeComments, arrayEquals, array2DEquals, arrayRemoveDuplicates, arrayToString, paramsToString, setEquals, readFile, writeFile };

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -1,0 +1,85 @@
+"use strict";
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+Object.defineProperty(exports, "__esModule", { value: true });
+const _ = require("lodash");
+const fs = require("fs");
+// escapeAssertion escapes the dots in the assertion,
+// because the expression evaluation doesn't support such variable names.
+function escapeAssertion(s) {
+    s = s.replace(/r\./g, 'r_');
+    s = s.replace(/p\./g, 'p_');
+    return s;
+}
+exports.escapeAssertion = escapeAssertion;
+// removeComments removes the comments starting with # in the text.
+function removeComments(s) {
+    const pos = s.indexOf('#');
+    return pos > -1 ? _.trim(s.slice(0, pos)) : s;
+}
+exports.removeComments = removeComments;
+// arrayEquals determines whether two string arrays are identical.
+function arrayEquals(a, b) {
+    return _.isEqual(a, b);
+}
+exports.arrayEquals = arrayEquals;
+// array2DEquals determines whether two 2-dimensional string arrays are identical.
+function array2DEquals(a, b) {
+    return _.isEqual(a, b);
+}
+exports.array2DEquals = array2DEquals;
+// arrayRemoveDuplicates removes any duplicated elements in a string array.
+function arrayRemoveDuplicates(s) {
+    return _.uniq(s);
+}
+exports.arrayRemoveDuplicates = arrayRemoveDuplicates;
+// arrayToString gets a printable string for a string array.
+function arrayToString(a) {
+    return _.join(a, ', ');
+}
+exports.arrayToString = arrayToString;
+// paramsToString gets a printable string for variable number of parameters.
+function paramsToString(...v) {
+    return _.join(v, ', ');
+}
+exports.paramsToString = paramsToString;
+// setEquals determines whether two string sets are identical.
+function setEquals(a, b) {
+    return _.isEqual(_.sortedUniq(a), _.sortedUniq(b));
+}
+exports.setEquals = setEquals;
+// readFile return a promise for readFile.
+function readFile(path, encoding) {
+    return new Promise((resolve, reject) => {
+        fs.readFile(path, encoding || 'utf8', (error, data) => {
+            if (error) {
+                reject(error);
+            }
+            resolve(data);
+        });
+    });
+}
+exports.readFile = readFile;
+// writeFile return a promise for writeFile.
+function writeFile(path, file, encoding) {
+    return new Promise((resolve, reject) => {
+        fs.writeFile(path, file, encoding || 'utf8', (error) => {
+            if (error) {
+                reject(error);
+            }
+            resolve(true);
+        });
+    });
+}
+exports.writeFile = writeFile;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "An authorization library that supports access control models like ACL, RBAC, ABAC in Node.JS",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "precommit": "lint-staged",
+    "precommit": "npm run build",
     "prepublishOnly": "yarn run lint && yarn run test && yarn build",
     "build": "rimraf lib && tsc",
     "lint": "tslint \"src/**/*.ts\"",

--- a/src/casbin.ts
+++ b/src/casbin.ts
@@ -64,7 +64,21 @@ async function newEnforcer(...params: any[]): Promise<Enforcer> {
     }
   }
 
-  if (params.length - parsedParamLen === 2) {
+  if (params.length - parsedParamLen === 3) {
+    if (typeof params[0] === 'string') {
+      if (typeof params[1] === 'string') {
+        await e.initWithFile(params[0].toString(), params[1].toString());
+      } else {
+        await e.initWithAdapter(params[0].toString(), params[1], params[2]);
+      }
+    } else {
+      if (typeof params[1] === 'string') {
+        throw new Error('Invalid parameters for enforcer.');
+      } else {
+        await e.initWithModelAndAdapter(params[0], params[1]);
+      }
+    }
+  } else if (params.length - parsedParamLen === 2) {
     if (typeof params[0] === 'string') {
       if (typeof params[1] === 'string') {
         await e.initWithFile(params[0].toString(), params[1].toString());

--- a/src/coreEnforcer.ts
+++ b/src/coreEnforcer.ts
@@ -155,11 +155,7 @@ export class CoreEnforcer {
   public async loadFilteredPolicy(filter: Filter): Promise<boolean> {
     this.model.clearPolicy();
 
-    if ((this.adapter as FilteredAdapter).isFiltered) {
-      await (this.adapter as FilteredAdapter).loadFilteredPolicy(this.model, filter);
-    } else {
-      throw new Error('filtered policies are not supported by this adapter');
-    }
+    await (this.adapter as FilteredAdapter).loadFilteredPolicy(this.model, filter);
 
     this.model.printPolicy();
     if (this.autoBuildRoleLinks) {

--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -294,11 +294,16 @@ export class Enforcer extends ManagementEnforcer {
    * getPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
    * But getImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
    */
-  public getImplicitPermissionsForUser(user: string) {
-    const roles = [user, ...this.getImplicitRolesForUser(user)];
+  public async getImplicitPermissionsForUser(user: string, ...domain: string[]): Promise<string[][]> {
+    const roles = [user, ...(await this.getImplicitRolesForUser(user, ...domain))];
     const res: string[][] = [];
+    const withDomain = domain && domain.length !== 0;
     roles.forEach(n => {
-      res.push(...this.getPermissionsForUser(n));
+      if (withDomain) {
+        res.push(...this.getFilteredPolicy(0, n, ...domain));
+      } else {
+        res.push(...this.getPermissionsForUser(n));
+      }
     });
     return res;
   }

--- a/src/enforcer.ts
+++ b/src/enforcer.ts
@@ -36,9 +36,9 @@ export class Enforcer extends ManagementEnforcer {
    * @param modelPath model file path
    * @param adapter current adapter instance
    */
-  public async initWithAdapter(modelPath: string, adapter: Adapter): Promise<void> {
+  public async initWithAdapter(modelPath: string, adapter: Adapter, filter: any = null): Promise<void> {
     const m = newModel(modelPath, '');
-    await this.initWithModelAndAdapter(m, adapter);
+    await this.initWithModelAndAdapter(m, adapter, filter);
 
     this.modelPath = modelPath;
   }
@@ -48,7 +48,7 @@ export class Enforcer extends ManagementEnforcer {
    * @param m model instance
    * @param adapter current adapter instance
    */
-  public async initWithModelAndAdapter(m: Model, adapter: Adapter): Promise<void> {
+  public async initWithModelAndAdapter(m: Model, adapter: Adapter, filter: any = null): Promise<void> {
     if (adapter) {
       this.adapter = adapter;
     }
@@ -59,7 +59,12 @@ export class Enforcer extends ManagementEnforcer {
 
     this.initialize();
 
-    if (this.adapter) {
+    if (this.adapter && filter) {
+      // error intentionally ignored
+      await this.loadFilteredPolicy(filter);
+    }
+
+    if (this.adapter && !filter) {
       // error intentionally ignored
       await this.loadPolicy();
     }


### PR DESCRIPTION
I'm just creating this PR so you can see what I changed to the casbin library. It cannot be merged to master since the version we were using was overwritten with new versions on master. The commit for my fix is tagged as v2.0.5, which is used in package.json on the api.

Because this also includes changes from 2.0.4 and all the /lib files and thus this is PR is crowded with irrelevant diff changes, please just take a look at commit https://github.com/site-mate/node-casbin/commit/eafff6fa7db9087cad8fa8107aa6fea926b51d56, this contains all the logical changes.

See breakdown of how I would change this long-term, when centralizing user management, in the writeup for it.